### PR TITLE
fix: handle broken files

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,7 +4,7 @@ import {
   Artifact,
   Fingerprint,
   Options,
-  TestResults,
+  TestResult,
   ScanResult,
   SupportFileExtensions,
 } from './types';
@@ -13,7 +13,7 @@ export {
   Artifact,
   Fingerprint,
   Options,
-  TestResults,
+  TestResult,
   ScanResult,
   SupportFileExtensions,
   display,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -42,7 +42,7 @@ export interface Options {
   path: string;
 }
 
-export interface TestResults {
+export interface TestResult {
   depGraph: DepGraphData;
   affectedPkgs: {
     [pkgId: string]: {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,11 @@
   },
   "dependencies": {
     "@snyk/dep-graph": "^1.19.3",
+    "debug": "^4.1.1",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.5",
     "@types/jest": "^25.2.3",
     "@types/node": "^8.10.62",
     "@typescript-eslint/eslint-plugin": "^3.8.0",

--- a/test/display.test.ts
+++ b/test/display.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { TestResults, display, scan } from '../lib';
+import { TestResult, display, scan } from '../lib';
 import { DepGraphBuilder } from '@snyk/dep-graph';
 
 describe('display', () => {
@@ -17,7 +17,7 @@ describe('display', () => {
     builder.addPkgNode(dep, nodeId);
     builder.connectDep(builder.rootNodeId, nodeId);
     const depGraph = builder.build().toJSON();
-    const testResults: TestResults[] = [
+    const testResults: TestResult[] = [
       {
         depGraph,
         affectedPkgs: {
@@ -60,7 +60,7 @@ describe('display', () => {
     builder.addPkgNode(dep, nodeId);
     builder.connectDep(builder.rootNodeId, nodeId);
     const depGraph = builder.build().toJSON();
-    const testResults: TestResults[] = [
+    const testResults: TestResult[] = [
       {
         depGraph,
         affectedPkgs: {},
@@ -80,7 +80,7 @@ describe('display', () => {
     );
     const scanResult = await scan({ path: fixturePath });
     const depGraph = new DepGraphBuilder({ name: 'cpp' }).build().toJSON();
-    const testResults: TestResults[] = [
+    const testResults: TestResult[] = [
       {
         depGraph,
         affectedPkgs: {},
@@ -99,7 +99,7 @@ describe('display', () => {
       'display-no-scan-results.txt',
     );
     const depGraph = new DepGraphBuilder({ name: 'cpp' }).build().toJSON();
-    const testResults: TestResults[] = [
+    const testResults: TestResult[] = [
       {
         depGraph,
         affectedPkgs: {},
@@ -118,7 +118,7 @@ describe('display', () => {
       'display-no-scan-results.txt',
     );
     const depGraph = new DepGraphBuilder({ name: 'cpp' }).build().toJSON();
-    const testResults: TestResults[] = [
+    const testResults: TestResult[] = [
       {
         depGraph,
         affectedPkgs: {},
@@ -137,7 +137,7 @@ describe('display', () => {
       'display-no-scan-results.txt',
     );
     const depGraph = new DepGraphBuilder({ name: 'cpp' }).build().toJSON();
-    const testResults: TestResults[] = [
+    const testResults: TestResult[] = [
       {
         depGraph,
         affectedPkgs: {},
@@ -160,7 +160,7 @@ describe('display', () => {
       'display-no-scan-results.txt',
     );
     const depGraph = new DepGraphBuilder({ name: 'cpp' }).build().toJSON();
-    const testResults: TestResults[] = [
+    const testResults: TestResult[] = [
       {
         depGraph,
         affectedPkgs: {},
@@ -189,7 +189,7 @@ describe('display', () => {
     builder.addPkgNode(dep, nodeId);
     builder.connectDep(builder.rootNodeId, nodeId);
     const depGraph = builder.build().toJSON();
-    const testResults: TestResults[] = [
+    const testResults: TestResult[] = [
       {
         depGraph,
         affectedPkgs: {
@@ -234,7 +234,7 @@ describe('display', () => {
     builder.addPkgNode(dep, nodeId);
     builder.connectDep(builder.rootNodeId, nodeId);
     const depGraph = builder.build().toJSON();
-    const testResults: TestResults[] = [
+    const testResults: TestResult[] = [
       {
         depGraph,
         affectedPkgs: {},

--- a/test/find.test.ts
+++ b/test/find.test.ts
@@ -60,4 +60,11 @@ describe('find', () => {
       expect(err).toEqual(expected);
     }
   });
+
+  it('should handle broken files and continue to find other files', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'handle-broken');
+    const actual = await find(fixturePath);
+    const expected: string[] = [path.join(fixturePath, 'main.cpp')];
+    expect(actual).toEqual(expected);
+  });
 });

--- a/test/fixtures/handle-broken/broken-symlink
+++ b/test/fixtures/handle-broken/broken-symlink
@@ -1,0 +1,1 @@
+/path-that-does-not-exist


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Add try/catch in find & display.
Debug caught errors to help diagnose problems.
Test that broken files don't fail entire scan.

#### How should this be manually tested?

npm link this library to Snyk CLI and run 'snyk source test' in directory with a broken file.

#### Any background context you want to provide?

Broken files were throwing exceptions, we should handle these and continue scanning.
