### PR TITLE
fix: remove type from ScanResult interface

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -25,7 +25,6 @@ export async function scan(options: Options): Promise<ScanResult[]> {
     ];
     const scanResults: ScanResult[] = [
       {
-        type: 'cpp',
         artifacts,
         meta: {},
       },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,7 +20,6 @@ export const SupportFileExtensions = [
   '.tpl',
 ];
 
-// TODO: use snyk-cli-interface
 export interface Artifact {
   type: string;
   data: any;
@@ -28,7 +27,6 @@ export interface Artifact {
 }
 
 export interface ScanResult {
-  type: string;
   artifacts: Artifact[];
   meta: { [key: string]: any };
 }

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -7,7 +7,6 @@ describe('scan', () => {
     const actual = await scan({ path: fixturePath });
     const expected: ScanResult[] = [
       {
-        type: 'cpp',
         artifacts: [
           {
             type: 'cpp-fingerprints',


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Remove type from ScanResult interface