### PR TITLE
feat: only show fingerprints when debug option set

### DIFF
--- a/lib/display.ts
+++ b/lib/display.ts
@@ -1,7 +1,7 @@
 import * as chalk from 'chalk';
-import Debug from 'debug';
-import { ScanResult, TestResult, IssuesData, Issue } from './types';
 import { createFromJSON, DepGraph } from '@snyk/dep-graph';
+import Debug from 'debug';
+import { ScanResult, TestResult, IssuesData, Issue, Options } from './types';
 
 const debug = Debug('snyk-cpp-plugin');
 
@@ -106,11 +106,14 @@ export async function display(
   scanResults: ScanResult[],
   testResults: TestResult[],
   errors: string[],
+  options?: Options,
 ): Promise<string> {
   try {
     const result: string[] = [];
-    const fingerprintLines = displayFingerprints(scanResults);
-    result.push(...fingerprintLines);
+    if (options?.debug) {
+      const fingerprintLines = displayFingerprints(scanResults);
+      result.push(...fingerprintLines);
+    }
     for (const testResult of testResults) {
       const depGraph = createFromJSON(testResult.depGraphData);
       const dependencyLines = displayDependencies(depGraph);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,6 +38,7 @@ export interface Fingerprint {
 
 export interface Options {
   path: string;
+  debug?: boolean;
 }
 
 export interface Issue {

--- a/test/display.test.ts
+++ b/test/display.test.ts
@@ -1,8 +1,9 @@
 import { join } from 'path';
-import { display, scan, ScanResult } from '../lib';
+import { display, Options, scan, ScanResult } from '../lib';
 import { readFixture } from './read-fixture';
 import {
-  withDepIssuesAndFix,
+  withDepOneIssueAndFix,
+  withDepThreeIssues,
   withDepNoIssues,
   noDepOrIssues,
 } from './fixtures/hello-world/test-results';
@@ -13,10 +14,36 @@ describe('display', () => {
   it('should return expected text for one dependency, one issue with fix, no errors', async () => {
     const scanResult = await scan({ path: helloWorldPath });
     const errors: string[] = [];
-    const actual = await display(scanResult, withDepIssuesAndFix, errors);
+    const actual = await display(scanResult, withDepOneIssueAndFix, errors);
     const expected = await readFixture(
       'hello-world',
       'display-one-dep-one-issue-with-fix-no-errors.txt',
+    );
+    expect(actual).toBe(expected);
+  });
+  it('should return expected text for one dependency, three issues, no errors', async () => {
+    const scanResult = await scan({ path: helloWorldPath });
+    const errors: string[] = [];
+    const actual = await display(scanResult, withDepThreeIssues, errors);
+    const expected = await readFixture(
+      'hello-world',
+      'display-one-dep-three-issues-no-errors.txt',
+    );
+    expect(actual).toBe(expected);
+  });
+  it('should return expected text for one dependency, one issue with fix, no errors when debug true', async () => {
+    const scanResult = await scan({ path: helloWorldPath });
+    const errors: string[] = [];
+    const options: Options = { path: '', debug: true };
+    const actual = await display(
+      scanResult,
+      withDepOneIssueAndFix,
+      errors,
+      options,
+    );
+    const expected = await readFixture(
+      'hello-world',
+      'display-one-dep-one-issue-with-fix-no-error-debug.txt',
     );
     expect(actual).toBe(expected);
   });
@@ -90,7 +117,7 @@ describe('display', () => {
     const errors: string[] = [
       'Could not test dependencies in test/fixtures/invalid',
     ];
-    const actual = await display(scanResult, withDepIssuesAndFix, errors);
+    const actual = await display(scanResult, withDepOneIssueAndFix, errors);
     const expected = await readFixture(
       'hello-world',
       'display-one-dep-one-issue-one-error.txt',

--- a/test/fixtures/hello-world/display-no-deps-no-issues-no-errors.txt
+++ b/test/fixtures/hello-world/display-no-deps-no-issues-no-errors.txt
@@ -1,7 +1,2 @@
-[97mFingerprints[39m
-52d1b046047db9ea0c581cafd4c68fe5 test/fixtures/hello-world/add.cpp
-aeca71a6e39f99a24ecf4c088eee9cb8 test/fixtures/hello-world/add.h
-ad3365b3370ef6b1c3e778f875055f19 test/fixtures/hello-world/main.cpp
-
 [97mIssues[39m
 Tested 0 dependencies for known issues, found [92m0 issues[39m.

--- a/test/fixtures/hello-world/display-one-dep-no-issues-no-errors.txt
+++ b/test/fixtures/hello-world/display-one-dep-no-issues-no-errors.txt
@@ -1,8 +1,3 @@
-[97mFingerprints[39m
-52d1b046047db9ea0c581cafd4c68fe5 test/fixtures/hello-world/add.cpp
-aeca71a6e39f99a24ecf4c088eee9cb8 test/fixtures/hello-world/add.h
-ad3365b3370ef6b1c3e778f875055f19 test/fixtures/hello-world/main.cpp
-
 [97mDependencies[39m
 hello-world@1.2.3
 

--- a/test/fixtures/hello-world/display-one-dep-no-issues-two-errors.txt
+++ b/test/fixtures/hello-world/display-one-dep-no-issues-two-errors.txt
@@ -1,8 +1,3 @@
-[97mFingerprints[39m
-52d1b046047db9ea0c581cafd4c68fe5 test/fixtures/hello-world/add.cpp
-aeca71a6e39f99a24ecf4c088eee9cb8 test/fixtures/hello-world/add.h
-ad3365b3370ef6b1c3e778f875055f19 test/fixtures/hello-world/main.cpp
-
 [97mDependencies[39m
 hello-world@1.2.3
 

--- a/test/fixtures/hello-world/display-one-dep-one-issue-with-fix-no-error-debug.txt
+++ b/test/fixtures/hello-world/display-one-dep-one-issue-with-fix-no-error-debug.txt
@@ -1,3 +1,8 @@
+[97mFingerprints[39m
+52d1b046047db9ea0c581cafd4c68fe5 test/fixtures/hello-world/add.cpp
+aeca71a6e39f99a24ecf4c088eee9cb8 test/fixtures/hello-world/add.h
+ad3365b3370ef6b1c3e778f875055f19 test/fixtures/hello-world/main.cpp
+
 [97mDependencies[39m
 hello-world@1.2.3
 
@@ -8,6 +13,3 @@ hello-world@1.2.3
   fix version 1.2.4
 
 Tested 1 dependency for known issues, found [91m1 issue[39m.
-
-[91mErrors[39m
-Could not test dependencies in test/fixtures/invalid

--- a/test/fixtures/hello-world/display-one-dep-one-issue-with-fix-no-errors.txt
+++ b/test/fixtures/hello-world/display-one-dep-one-issue-with-fix-no-errors.txt
@@ -1,8 +1,3 @@
-[97mFingerprints[39m
-52d1b046047db9ea0c581cafd4c68fe5 test/fixtures/hello-world/add.cpp
-aeca71a6e39f99a24ecf4c088eee9cb8 test/fixtures/hello-world/add.h
-ad3365b3370ef6b1c3e778f875055f19 test/fixtures/hello-world/main.cpp
-
 [97mDependencies[39m
 hello-world@1.2.3
 

--- a/test/fixtures/hello-world/display-one-dep-three-issues-no-errors.txt
+++ b/test/fixtures/hello-world/display-one-dep-three-issues-no-errors.txt
@@ -1,0 +1,18 @@
+[97mDependencies[39m
+hello-world@1.2.3
+
+[97mIssues[39m
+[91m✗ Information Exposure [high][39m
+  https://snyk.io/vuln/cpp:hello-world:123
+  in hello-world@1.2.3
+  no fix available
+[93m✗ Use of Insufficiently Random Values [medium][39m
+  https://snyk.io/vuln/cpp:hello-world:456
+  in hello-world@1.2.3
+  no fix available
+[94m✗ Missing Encryption of Sensitive Data [low][39m
+  https://snyk.io/vuln/cpp:hello-world:789
+  in hello-world@1.2.3
+  no fix available
+
+Tested 1 dependency for known issues, found [91m3 issues[39m.

--- a/test/fixtures/hello-world/test-results.ts
+++ b/test/fixtures/hello-world/test-results.ts
@@ -17,7 +17,7 @@ function noDeps(): DepGraphData {
   return depGraph.toJSON();
 }
 
-export const withDepIssuesAndFix: TestResult[] = [
+export const withDepOneIssueAndFix: TestResult[] = [
   {
     depGraphData: withDep(),
     issues: [
@@ -35,6 +35,49 @@ export const withDepIssuesAndFix: TestResult[] = [
         id: 'cpp:hello-world:20161130',
         severity: 'medium',
         title: 'Cross-site Scripting (XSS)',
+      },
+    },
+  },
+];
+
+export const withDepThreeIssues: TestResult[] = [
+  {
+    depGraphData: withDep(),
+    issues: [
+      {
+        pkgName: 'hello-world',
+        pkgVersion: '1.2.3',
+        issueId: 'cpp:hello-world:123',
+        fixInfo: {},
+      },
+      {
+        pkgName: 'hello-world',
+        pkgVersion: '1.2.3',
+        issueId: 'cpp:hello-world:456',
+        fixInfo: {},
+      },
+      {
+        pkgName: 'hello-world',
+        pkgVersion: '1.2.3',
+        issueId: 'cpp:hello-world:789',
+        fixInfo: {},
+      },
+    ],
+    issuesData: {
+      ['cpp:hello-world:123']: {
+        id: 'cpp:hello-world:20161130',
+        severity: 'high',
+        title: 'Information Exposure',
+      },
+      ['cpp:hello-world:456']: {
+        id: 'cpp:hello-world:20161130',
+        severity: 'medium',
+        title: 'Use of Insufficiently Random Values',
+      },
+      ['cpp:hello-world:789']: {
+        id: 'cpp:hello-world:20161130',
+        severity: 'low',
+        title: 'Missing Encryption of Sensitive Data',
       },
     },
   },


### PR DESCRIPTION


- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
To make display more readable during normal operations
hide fingerprint information unless user sets debug to true.

