### PR TITLE
feat: update types with plugin response

### DIFF
--- a/lib/display.ts
+++ b/lib/display.ts
@@ -7,8 +7,8 @@ const debug = Debug('snyk-cpp-plugin');
 
 function displayFingerprints(scanResults: ScanResult[]): string[] {
   const result: string[] = [];
-  for (const { artifacts = [] } of scanResults) {
-    for (const { data = [] } of artifacts) {
+  for (const { facts = [] } of scanResults) {
+    for (const { data = [] } of facts) {
       for (const { filePath, hash } of data) {
         if (filePath && hash) {
           if (!result.length) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import { display } from './display';
 import { scan } from './scan';
 import {
-  Artifact,
+  PluginResponse,
   Fingerprint,
   Options,
   TestResult,
@@ -10,7 +10,7 @@ import {
 } from './types';
 
 export {
-  Artifact,
+  PluginResponse,
   Fingerprint,
   Options,
   TestResult,

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -1,9 +1,15 @@
 import * as fs from 'fs';
 import { find } from './find';
 import { hash } from './hash';
-import { ScanResult, Options, Fingerprint, Artifact } from './types';
+import {
+  ScanResult,
+  Options,
+  Fingerprint,
+  Facts,
+  PluginResponse,
+} from './types';
 
-export async function scan(options: Options): Promise<ScanResult[]> {
+export async function scan(options: Options): Promise<PluginResponse> {
   try {
     if (!options.path) {
       throw 'invalid options no path provided.';
@@ -20,16 +26,18 @@ export async function scan(options: Options): Promise<ScanResult[]> {
         hash: md5,
       });
     }
-    const artifacts: Artifact[] = [
-      { type: 'cpp-fingerprints', data: fingerprints, meta: {} },
-    ];
+    const facts: Facts[] = [{ type: 'cpp-fingerprints', data: fingerprints }];
     const scanResults: ScanResult[] = [
       {
-        artifacts,
-        meta: {},
+        facts,
+        identity: {
+          type: 'cpp',
+        },
       },
     ];
-    return scanResults;
+    return {
+      scanResults,
+    };
   } catch (error) {
     throw new Error(`Could not scan C/C++ project, ${error}`);
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,15 +20,26 @@ export const SupportFileExtensions = [
   '.tpl',
 ];
 
-export interface Artifact {
-  type: string;
-  data: any;
-  meta: { [key: string]: any };
+export interface PluginResponse {
+  scanResults: ScanResult[];
 }
 
 export interface ScanResult {
-  artifacts: Artifact[];
-  meta: { [key: string]: any };
+  identity: Identity;
+  facts: Facts[];
+  name?: string;
+  policy?: string;
+}
+
+export interface Identity {
+  type: string;
+  targetFile?: string;
+  args?: { [key: string]: string };
+}
+
+export interface Facts {
+  type: string;
+  data: any;
 }
 
 export interface Fingerprint {
@@ -46,7 +57,7 @@ export interface Issue {
   pkgVersion?: string;
   issueId: string;
   fixInfo: {
-    nearestFixedInVersion?: string; // TODO: add more fix info
+    nearestFixedInVersion?: string;
   };
 }
 

--- a/test/display.test.ts
+++ b/test/display.test.ts
@@ -12,9 +12,9 @@ const helloWorldPath = join('./', 'test', 'fixtures', 'hello-world');
 
 describe('display', () => {
   it('should return expected text for one dependency, one issue with fix, no errors', async () => {
-    const scanResult = await scan({ path: helloWorldPath });
+    const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [];
-    const actual = await display(scanResult, withDepOneIssueAndFix, errors);
+    const actual = await display(scanResults, withDepOneIssueAndFix, errors);
     const expected = await readFixture(
       'hello-world',
       'display-one-dep-one-issue-with-fix-no-errors.txt',
@@ -22,9 +22,9 @@ describe('display', () => {
     expect(actual).toBe(expected);
   });
   it('should return expected text for one dependency, three issues, no errors', async () => {
-    const scanResult = await scan({ path: helloWorldPath });
+    const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [];
-    const actual = await display(scanResult, withDepThreeIssues, errors);
+    const actual = await display(scanResults, withDepThreeIssues, errors);
     const expected = await readFixture(
       'hello-world',
       'display-one-dep-three-issues-no-errors.txt',
@@ -32,11 +32,11 @@ describe('display', () => {
     expect(actual).toBe(expected);
   });
   it('should return expected text for one dependency, one issue with fix, no errors when debug true', async () => {
-    const scanResult = await scan({ path: helloWorldPath });
+    const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [];
     const options: Options = { path: '', debug: true };
     const actual = await display(
-      scanResult,
+      scanResults,
       withDepOneIssueAndFix,
       errors,
       options,
@@ -48,9 +48,9 @@ describe('display', () => {
     expect(actual).toBe(expected);
   });
   it('should return expected text when one dependency, no issues, no errors', async () => {
-    const scanResult = await scan({ path: helloWorldPath });
+    const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [];
-    const actual = await display(scanResult, withDepNoIssues, errors);
+    const actual = await display(scanResults, withDepNoIssues, errors);
     const expected = await readFixture(
       'hello-world',
       'display-one-dep-no-issues-no-errors.txt',
@@ -58,9 +58,9 @@ describe('display', () => {
     expect(actual).toBe(expected);
   });
   it('should return expected text when no dependencies, no issues, no errors', async () => {
-    const scanResult = await scan({ path: helloWorldPath });
+    const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [];
-    const actual = await display(scanResult, noDepOrIssues, errors);
+    const actual = await display(scanResults, noDepOrIssues, errors);
     const expected = await readFixture(
       'hello-world',
       'display-no-deps-no-issues-no-errors.txt',
@@ -113,11 +113,11 @@ describe('display', () => {
     expect(actual).toBe(expected);
   });
   it('should return expected text for one dependency, one issue, one error', async () => {
-    const scanResult = await scan({ path: helloWorldPath });
+    const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [
       'Could not test dependencies in test/fixtures/invalid',
     ];
-    const actual = await display(scanResult, withDepOneIssueAndFix, errors);
+    const actual = await display(scanResults, withDepOneIssueAndFix, errors);
     const expected = await readFixture(
       'hello-world',
       'display-one-dep-one-issue-one-error.txt',
@@ -125,12 +125,12 @@ describe('display', () => {
     expect(actual).toBe(expected);
   });
   it('should return expected text for one dependency, no issues, two errors', async () => {
-    const scanResult = await scan({ path: helloWorldPath });
+    const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [
       'Could not test dependencies in test/fixtures/invalid1',
       'Could not test dependencies in test/fixtures/invalid2',
     ];
-    const actual = await display(scanResult, withDepNoIssues, errors);
+    const actual = await display(scanResults, withDepNoIssues, errors);
     const expected = await readFixture(
       'hello-world',
       'display-one-dep-no-issues-two-errors.txt',

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -1,35 +1,38 @@
 import * as path from 'path';
-import { ScanResult, scan } from '../lib';
+import { scan, PluginResponse } from '../lib';
 
 describe('scan', () => {
   it('should produce scanned projects', async () => {
     const fixturePath = path.join(__dirname, 'fixtures', 'hello-world');
     const actual = await scan({ path: fixturePath });
-    const expected: ScanResult[] = [
-      {
-        artifacts: [
-          {
-            type: 'cpp-fingerprints',
-            data: [
-              {
-                filePath: path.join(fixturePath, 'add.cpp'),
-                hash: '52d1b046047db9ea0c581cafd4c68fe5',
-              },
-              {
-                filePath: path.join(fixturePath, 'add.h'),
-                hash: 'aeca71a6e39f99a24ecf4c088eee9cb8',
-              },
-              {
-                filePath: path.join(fixturePath, 'main.cpp'),
-                hash: 'ad3365b3370ef6b1c3e778f875055f19',
-              },
-            ],
-            meta: {},
+    const expected: PluginResponse = {
+      scanResults: [
+        {
+          facts: [
+            {
+              type: 'cpp-fingerprints',
+              data: [
+                {
+                  filePath: path.join(fixturePath, 'add.cpp'),
+                  hash: '52d1b046047db9ea0c581cafd4c68fe5',
+                },
+                {
+                  filePath: path.join(fixturePath, 'add.h'),
+                  hash: 'aeca71a6e39f99a24ecf4c088eee9cb8',
+                },
+                {
+                  filePath: path.join(fixturePath, 'main.cpp'),
+                  hash: 'ad3365b3370ef6b1c3e778f875055f19',
+                },
+              ],
+            },
+          ],
+          identity: {
+            type: 'cpp',
           },
-        ],
-        meta: {},
-      },
-    ];
+        },
+      ],
+    };
     expect(actual).toEqual(expected);
   });
 


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

BREAKING CHANGE: Change scan response to plugin response.

Plugin response contains scan results, which have the following
properties:

* `facts` what we scanned
* `identity` where we scanned
* `target` git information

Note: snyk-cpp-plugin current ignores target until monitor is supported.

#### Where should the reviewer start?
lib/types.ts