### PR TITLE
feat: add target and name to scan result

### DIFF
--- a/lib/child-process.ts
+++ b/lib/child-process.ts
@@ -1,0 +1,29 @@
+import * as childProcess from 'child_process';
+
+export async function spawn(
+  command: string,
+  args?: string[],
+  options?: childProcess.SpawnOptions,
+): Promise<{
+  code: number;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    const process = childProcess.spawn(command, args, options);
+    process.stdout.on('data', (data: string | Buffer) => {
+      stdout += data;
+    });
+    process.stderr.on('data', (data: string | Buffer) => {
+      stderr += data;
+    });
+    process.on('close', (code: number) => {
+      resolve({ code, stdout, stderr });
+    });
+    process.on('error', (err) => {
+      reject(err);
+    });
+  });
+}

--- a/lib/debug.ts
+++ b/lib/debug.ts
@@ -1,0 +1,3 @@
+import Debug from 'debug';
+
+export const debug = Debug('snyk-cpp-plugin');

--- a/lib/display.ts
+++ b/lib/display.ts
@@ -1,9 +1,7 @@
 import * as chalk from 'chalk';
 import { createFromJSON, DepGraph } from '@snyk/dep-graph';
-import Debug from 'debug';
+import { debug } from './debug';
 import { ScanResult, TestResult, IssuesData, Issue, Options } from './types';
-
-const debug = Debug('snyk-cpp-plugin');
 
 function displayFingerprints(scanResults: ScanResult[]): string[] {
   const result: string[] = [];

--- a/lib/find.ts
+++ b/lib/find.ts
@@ -1,9 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { SupportFileExtensions } from './types';
-import Debug from 'debug';
-
-const debug = Debug('snyk-cpp-plugin');
+import { debug } from './debug';
 
 export async function find(dir: string): Promise<string[]> {
   const result: string[] = [];

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -1,0 +1,19 @@
+import { GitTarget } from './types';
+import { spawn } from './child-process';
+
+export async function getTarget(): Promise<GitTarget> {
+  try {
+    const remote = await spawn('git', ['remote', 'get-url', 'origin']);
+    const revParse = await spawn('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
+    return {
+      remoteUrl: remote.stdout.trim(),
+      branch: revParse.stdout.trim(),
+    };
+  } catch (err) {
+    // when git is not installed
+    return {
+      remoteUrl: '',
+      branch: '',
+    };
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,6 +29,7 @@ export interface ScanResult {
   facts: Facts[];
   name?: string;
   policy?: string;
+  target: GitTarget;
 }
 
 export interface Identity {
@@ -42,6 +43,11 @@ export interface Facts {
   data: any;
 }
 
+export interface GitTarget {
+  remoteUrl: string;
+  branch: string;
+}
+
 export interface Fingerprint {
   filePath: string;
   hash: string;
@@ -50,6 +56,7 @@ export interface Fingerprint {
 export interface Options {
   path: string;
   debug?: boolean;
+  projectName?: string;
 }
 
 export interface Issue {

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
     "@snyk/dep-graph": "^1.19.3",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",
+    "hosted-git-info": "^3.0.7",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",
+    "@types/hosted-git-info": "^3.0.1",
     "@types/jest": "^25.2.3",
     "@types/node": "^8.10.62",
     "@typescript-eslint/eslint-plugin": "^3.8.0",

--- a/test/child-process.test.ts
+++ b/test/child-process.test.ts
@@ -1,0 +1,20 @@
+import { spawn } from '../lib/child-process';
+
+describe('spawn', () => {
+  it('should resolve when command exists', async () => {
+    const actual = await spawn('node', ['--version']);
+    expect(actual).toMatchObject({
+      code: expect.any(Number),
+      stdout: expect.any(String),
+      stderr: expect.any(String),
+    });
+  });
+  it('should reject when command does not exist', async () => {
+    expect.assertions(1);
+    try {
+      await spawn('does-not-exist');
+    } catch (err) {
+      expect(err).toBeTruthy();
+    }
+  });
+});

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,0 +1,52 @@
+import { fromUrl } from 'hosted-git-info';
+import { getTarget } from '../lib/git';
+import * as childProcess from '../lib/child-process';
+import { SpawnOptions } from 'child_process';
+
+function mockSpawn(arg: string) {
+  return (
+    _command: string,
+    args?: string[],
+    _options?: SpawnOptions,
+  ): Promise<{ code: number; stdout: string; stderr: string }> => {
+    if (args?.includes(arg)) {
+      return Promise.resolve({ code: 1, stdout: '', stderr: 'error' });
+    }
+    return Promise.resolve({ code: 0, stdout: 'success', stderr: '' });
+  };
+}
+
+describe('gitTarget', () => {
+  afterEach(() => jest.resetAllMocks());
+  it('should return git target', async () => {
+    const { remoteUrl, branch } = await getTarget();
+    const info = fromUrl(remoteUrl);
+    expect(info).toMatchObject({
+      user: 'snyk',
+      project: 'snyk-cpp-plugin',
+    });
+    expect(branch).toBeTruthy();
+  });
+  it('should return empty remote url when git remote command fails', async () => {
+    const mock = mockSpawn('remote');
+    jest.spyOn(childProcess, 'spawn').mockImplementation(mock);
+    const { remoteUrl, branch } = await getTarget();
+    expect(remoteUrl).toBe('');
+    expect(branch).toBeTruthy();
+  });
+  it('should return empty branch when git rev-parse command fails', async () => {
+    const mock = mockSpawn('rev-parse');
+    jest.spyOn(childProcess, 'spawn').mockImplementation(mock);
+    const { remoteUrl, branch } = await getTarget();
+    expect(remoteUrl).toBeTruthy();
+    expect(branch).toBe('');
+  });
+  it('should return empty remote url and branch when spawn rejects', async () => {
+    jest.spyOn(childProcess, 'spawn').mockRejectedValue({ message: 'error' });
+    const target = await getTarget();
+    expect(target).toEqual({
+      remoteUrl: '',
+      branch: '',
+    });
+  });
+});

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -1,34 +1,63 @@
 import * as path from 'path';
 import { scan, PluginResponse } from '../lib';
+import { Facts } from '../lib/types';
+
+const helloWorldFixturePath = path.join(__dirname, 'fixtures', 'hello-world');
+const helloWorldFingerprints: Facts[] = [
+  {
+    type: 'cpp-fingerprints',
+    data: [
+      {
+        filePath: path.join(helloWorldFixturePath, 'add.cpp'),
+        hash: '52d1b046047db9ea0c581cafd4c68fe5',
+      },
+      {
+        filePath: path.join(helloWorldFixturePath, 'add.h'),
+        hash: 'aeca71a6e39f99a24ecf4c088eee9cb8',
+      },
+      {
+        filePath: path.join(helloWorldFixturePath, 'main.cpp'),
+        hash: 'ad3365b3370ef6b1c3e778f875055f19',
+      },
+    ],
+  },
+];
 
 describe('scan', () => {
   it('should produce scanned projects', async () => {
-    const fixturePath = path.join(__dirname, 'fixtures', 'hello-world');
-    const actual = await scan({ path: fixturePath });
+    const actual = await scan({ path: helloWorldFixturePath });
     const expected: PluginResponse = {
       scanResults: [
         {
-          facts: [
-            {
-              type: 'cpp-fingerprints',
-              data: [
-                {
-                  filePath: path.join(fixturePath, 'add.cpp'),
-                  hash: '52d1b046047db9ea0c581cafd4c68fe5',
-                },
-                {
-                  filePath: path.join(fixturePath, 'add.h'),
-                  hash: 'aeca71a6e39f99a24ecf4c088eee9cb8',
-                },
-                {
-                  filePath: path.join(fixturePath, 'main.cpp'),
-                  hash: 'ad3365b3370ef6b1c3e778f875055f19',
-                },
-              ],
-            },
-          ],
+          facts: helloWorldFingerprints,
           identity: {
             type: 'cpp',
+          },
+          name: 'snyk-cpp-plugin',
+          target: {
+            remoteUrl: expect.any(String),
+            branch: expect.any(String),
+          },
+        },
+      ],
+    };
+    expect(actual).toEqual(expected);
+  });
+
+  it('should produce scanned projects with project name option', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'hello-world');
+    const actual = await scan({ path: fixturePath, projectName: 'my-app' });
+    const expected: PluginResponse = {
+      scanResults: [
+        {
+          facts: helloWorldFingerprints,
+          identity: {
+            type: 'cpp',
+          },
+          name: 'my-app',
+          target: {
+            remoteUrl: expect.any(String),
+            branch: expect.any(String),
           },
         },
       ],


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Spawn git child processes to find git remote url and branch
If git is not installed default to empty
Set name to:
1. user provided value in option
2. git project name
3. working directory folder name
In that order of preference

#### Any background context you want to provide?
In preparation for `snyk source monitor`
