### PR TITLE
feat: send plugin analytics to cli

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as pMap from 'p-map';
 
-import { Facts, Options, PluginResponse, ScanResult } from './types';
+import { Analytics, Facts, Options, PluginResponse, ScanResult } from './types';
 import { SignatureResult } from './types';
 import { debug } from './debug';
 import { find } from './find';
@@ -50,6 +50,16 @@ export async function scan(options: Options): Promise<PluginResponse> {
       { type: 'fileSignatures', data: filteredSignatures },
     ];
 
+    const analytics: Analytics[] = [
+      {
+        name: 'fileSignaturesAnalyticsContext',
+        data: {
+          totalFileSignatures,
+          totalSecondsElapsedToGenerateFileSignatures,
+        },
+      },
+    ];
+
     const target = await getTarget();
     debug('target %o \n', target);
     const gitInfo = fromUrl(target.remoteUrl);
@@ -64,6 +74,7 @@ export async function scan(options: Options): Promise<PluginResponse> {
         },
         name,
         target,
+        analytics,
       },
     ];
     return {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,8 +9,13 @@ export interface ScanResult {
   name?: string;
   policy?: string;
   target: GitTarget;
+  analytics?: Analytics[];
 }
 
+export interface Analytics {
+  name: string;
+  data: unknown;
+}
 export interface Identity {
   type: string;
   targetFile?: string;

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -57,6 +57,15 @@ describe('scan', () => {
             remoteUrl: expect.any(String),
             branch: expect.any(String),
           },
+          analytics: [
+            {
+              data: {
+                totalFileSignatures: 3,
+                totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
+              },
+              name: 'fileSignaturesAnalyticsContext',
+            },
+          ],
         },
       ],
     };
@@ -84,6 +93,15 @@ describe('scan', () => {
             remoteUrl: expect.any(String),
             branch: expect.any(String),
           },
+          analytics: [
+            {
+              data: {
+                totalFileSignatures: 3,
+                totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
+              },
+              name: 'fileSignaturesAnalyticsContext',
+            },
+          ],
         },
       ],
     };


### PR DESCRIPTION
This pr allows the snyk cli of receive a list of analytics collected in
the plugin level, in this case we are sending the total number of
fileSignatures that have been generated and the total seconds elapsed it
took to generate them.
