### PR TITLE
perf(uhash): Speed up uhash calculations

### DIFF
--- a/lib/uhash.ts
+++ b/lib/uhash.ts
@@ -43,19 +43,26 @@ function isUtf8BomPresent(fileBuffer: Buffer): boolean {
   return Utf8Bom.compare(fileBuffer.subarray(0, 3)) === 0;
 }
 
+function includeChar(c: number): boolean {
+  return (
+    c > 0x20 ||
+    (c != 0x20 && c != 0x0d && c != 0x0a && c != 0x09 && c != 0x0b && c != 0x0c)
+  );
+}
+
 function removeWhitespaceBytewise(
   fileBuffer: Buffer,
   startingIndex: number,
 ): Buffer {
-  const BYTES_TO_REMOVE = new Uint8Array([0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x20]);
   let writeIndex = 0;
   for (
     let readIndex = startingIndex;
     readIndex < fileBuffer.length;
     readIndex++
   ) {
-    if (!BYTES_TO_REMOVE.includes(fileBuffer[readIndex])) {
-      fileBuffer[writeIndex] = fileBuffer[readIndex];
+    const c = fileBuffer[readIndex];
+    if (includeChar(c)) {
+      fileBuffer[writeIndex] = c;
       writeIndex++;
     }
   }


### PR DESCRIPTION
uhash is now faster than dubhash, and almost as fast as half-dubhash.

- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

tldr: makes uhash faster

we found that uhash was significantly slower than expected.
uhash does less work than dubhash, and should therefore be faster.
now it is.

#### Where should the reviewer start?

at the top, and then read downwards

#### How should this be manually tested?

this is tested with unit tests

#### Any background context you want to provide?

before delopying uhash we need to make sure the performance is as expected

#### What are the relevant tickets?

#### Screenshots

#### Additional questions
