### PR TITLE
display relative paths based on project path

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -17,9 +17,11 @@ export async function scan(options: Options): Promise<PluginResponse> {
     if (!options.path) {
       throw 'invalid options: no path provided.';
     }
+
     if (!fs.existsSync(options.path)) {
       throw `'${options.path}' does not exist.`;
     }
+
     const start = Date.now();
     const filePaths = await find(options.path);
     debug('%d files found \n', filePaths.length);
@@ -31,6 +33,10 @@ export async function scan(options: Options): Promise<PluginResponse> {
     const filteredSignatures: SignatureResult[] = allSignatures.filter((s) => {
       return s !== null;
     }) as SignatureResult[];
+
+    filteredSignatures.forEach((s) => {
+      s.path = path.relative(options.path, s.path);
+    });
 
     const end = Date.now();
     const totalMilliseconds = end - start;
@@ -76,6 +82,7 @@ export async function scan(options: Options): Promise<PluginResponse> {
         analytics,
       },
     ];
+
     return {
       scanResults,
     };

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -10,7 +10,7 @@ const helloWorldSignatures: Facts[] = [
     type: 'fileSignatures',
     data: [
       {
-        path: path.join(helloWorldFixturePath, 'add.cpp'),
+        path: 'add.cpp',
         hashes_ffm: [
           {
             format: 1,
@@ -19,7 +19,7 @@ const helloWorldSignatures: Facts[] = [
         ],
       },
       {
-        path: path.join(helloWorldFixturePath, 'add.h'),
+        path: 'add.h',
         hashes_ffm: [
           {
             format: 1,
@@ -28,7 +28,7 @@ const helloWorldSignatures: Facts[] = [
         ],
       },
       {
-        path: path.join(helloWorldFixturePath, 'main.cpp'),
+        path: 'main.cpp',
         hashes_ffm: [
           {
             format: 1,


### PR DESCRIPTION
Replace absolute path with relative path when we
filter the signature result.

Due to this change, we will limit the artifact on
server side, to only contain the relative path.

Relevant tickets:

- TUN-85
