### PR TITLE
Refactor hash strategy selection

### DIFF
--- a/lib/find.ts
+++ b/lib/find.ts
@@ -1,12 +1,17 @@
 import * as fs from 'fs';
 import { join } from 'path';
+import { relative } from 'path';
 import { promisify } from 'util';
 import { debug } from './debug';
 
 const readdir = promisify(fs.readdir);
 const stat = promisify(fs.stat);
 
-export async function find(dir: string): Promise<string[]> {
+export async function find(dir: string, basedir?: string): Promise<string[]> {
+  if (basedir === undefined) {
+    basedir = dir;
+  }
+
   const result: string[] = [];
 
   const dirStat = await stat(dir);
@@ -18,16 +23,18 @@ export async function find(dir: string): Promise<string[]> {
 
   for (const relativePath of paths) {
     const absolutePath = join(dir, relativePath);
+
     try {
       const fileStat = await stat(absolutePath);
       if (fileStat.isDirectory()) {
-        const subFiles = await find(absolutePath);
+        const subFiles = await find(absolutePath, basedir);
         for (const file of subFiles) {
           result.push(file);
         }
       }
+
       if (fileStat.isFile()) {
-        result.push(absolutePath);
+        result.push(relative(basedir, absolutePath));
       }
     } catch (error) {
       debug(error.message || `Error reading file ${relativePath}. ${error}`);

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -25,6 +25,7 @@ export async function scan(options: Options): Promise<PluginResponse> {
     debug('%d files found \n', filePaths.length);
 
     const allSignatures: (SignatureResult | null)[] = await getSignaturesByAlgorithm(
+      options.path,
       filePaths,
     );
 
@@ -76,6 +77,7 @@ export async function scan(options: Options): Promise<PluginResponse> {
         analytics,
       },
     ];
+
     return {
       scanResults,
     };

--- a/lib/signatures.ts
+++ b/lib/signatures.ts
@@ -3,35 +3,47 @@ import { SignatureHashAlgorithm, SignatureResult } from './types';
 import { getDubHashSignature } from './dubhash';
 import { getUhashSignature } from './uhash';
 import pMap = require('p-map');
+import { join } from 'path';
 
 const { readFile } = promises;
 
 export async function getSignaturesByAlgorithm(
+  baseDir: string,
   filePaths: string[],
   hashType: SignatureHashAlgorithm = 'dubhash',
 ): Promise<(SignatureResult | null)[]> {
   if (hashType !== 'dubhash' && hashType !== 'uhash') {
     throw new Error(`Unsupported hashType ${hashType}`);
   }
-  let signatureMapperToBeUsed = getDubHashSignatureMapper;
+  let signatureMapperToBeUsed = getDubHashSignatureMapper(baseDir);
   if (hashType === 'uhash') {
-    signatureMapperToBeUsed = getUHashSignatureMapper;
+    signatureMapperToBeUsed = getUHashSignatureMapper(baseDir);
   }
-  return await pMap(filePaths, signatureMapperToBeUsed, { concurrency: 20 });
+  return await pMap(filePaths, signatureMapperToBeUsed, {
+    concurrency: 20,
+  });
 }
 
-async function getDubHashSignatureMapper(
-  filePath: string,
-): Promise<SignatureResult | null> {
-  const fileContents = await readFile(filePath);
-  if (fileContents.length === 0) return null;
-  return getDubHashSignature(filePath, fileContents);
+interface HashSignatureMapper {
+  (path: string): Promise<SignatureResult | null>;
 }
 
-async function getUHashSignatureMapper(
-  filePath: string,
-): Promise<SignatureResult | null> {
-  const fileContents = await readFile(filePath);
-  if (fileContents.length === 0) return null;
-  return getUhashSignature(filePath, fileContents);
+function getDubHashSignatureMapper(baseDir: string): HashSignatureMapper {
+  return async function(filePath: string): Promise<SignatureResult | null> {
+    const absolutePath = join(baseDir, filePath);
+    const fileContents = await readFile(absolutePath);
+
+    if (fileContents.length === 0) return null;
+    return getDubHashSignature(filePath, fileContents);
+  };
+}
+
+function getUHashSignatureMapper(baseDir: string): HashSignatureMapper {
+  return async function(filePath: string): Promise<SignatureResult | null> {
+    const absolutePath = join(baseDir, filePath);
+    const fileContents = await readFile(absolutePath);
+
+    if (fileContents.length === 0) return null;
+    return getUhashSignature(filePath, fileContents);
+  };
 }

--- a/lib/signatures.ts
+++ b/lib/signatures.ts
@@ -1,5 +1,5 @@
 import { promises } from 'fs';
-import { SignatureHashAlgorithm, SignatureResult } from './types';
+import { SignatureFormat, SignatureResult } from './types';
 import { getDubHashSignature } from './dubhash';
 import { getUhashSignature } from './uhash';
 import pMap = require('p-map');
@@ -7,43 +7,37 @@ import { join } from 'path';
 
 const { readFile } = promises;
 
+type Signer = (path: string, content: Buffer) => SignatureResult | null;
+interface SignatureFormatMap {
+  [SignatureFormat: string]: Signer;
+}
+
+const algorithms: SignatureFormatMap = {
+  dubhash: getDubHashSignature,
+  uhash: getUhashSignature,
+};
+
 export async function getSignaturesByAlgorithm(
   baseDir: string,
   filePaths: string[],
-  hashType: SignatureHashAlgorithm = 'dubhash',
+  hashType: SignatureFormat = 'dubhash',
 ): Promise<(SignatureResult | null)[]> {
-  if (hashType !== 'dubhash' && hashType !== 'uhash') {
+  const getSignature = algorithms[hashType];
+
+  if (getSignature === undefined) {
     throw new Error(`Unsupported hashType ${hashType}`);
   }
-  let signatureMapperToBeUsed = getDubHashSignatureMapper(baseDir);
-  if (hashType === 'uhash') {
-    signatureMapperToBeUsed = getUHashSignatureMapper(baseDir);
-  }
-  return await pMap(filePaths, signatureMapperToBeUsed, {
+
+  const generateSignatureFromPath = async (path: string) => {
+    const absolutePath = join(baseDir, path);
+    const fileContents = await readFile(absolutePath);
+
+    if (fileContents.length === 0) return null;
+
+    return getSignature(path, fileContents);
+  };
+
+  return await pMap(filePaths, generateSignatureFromPath, {
     concurrency: 20,
   });
-}
-
-interface HashSignatureMapper {
-  (path: string): Promise<SignatureResult | null>;
-}
-
-function getDubHashSignatureMapper(baseDir: string): HashSignatureMapper {
-  return async function(filePath: string): Promise<SignatureResult | null> {
-    const absolutePath = join(baseDir, filePath);
-    const fileContents = await readFile(absolutePath);
-
-    if (fileContents.length === 0) return null;
-    return getDubHashSignature(filePath, fileContents);
-  };
-}
-
-function getUHashSignatureMapper(baseDir: string): HashSignatureMapper {
-  return async function(filePath: string): Promise<SignatureResult | null> {
-    const absolutePath = join(baseDir, filePath);
-    const fileContents = await readFile(absolutePath);
-
-    if (fileContents.length === 0) return null;
-    return getUhashSignature(filePath, fileContents);
-  };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -49,7 +49,7 @@ export interface Options {
   'print-dep-paths'?: boolean;
 }
 
-export type SignatureHashAlgorithm = 'dubhash' | 'uhash';
+export type SignatureFormat = 'dubhash' | 'uhash';
 export interface Issue {
   pkgName: string;
   pkgVersion?: string;

--- a/test/find.test.ts
+++ b/test/find.test.ts
@@ -8,29 +8,29 @@ describe('find', () => {
     const actual = await find(fixturePath);
     const expected = [
       // md file
-      path.join(fixturePath, 'README.md'),
+      path.join('README.md'),
       // c* files
-      path.join(fixturePath, 'test.c'),
-      path.join(fixturePath, 'main.cpp'),
-      path.join(fixturePath, 'main.cc'),
-      path.join(fixturePath, 'one', 'one.cc'),
-      path.join(fixturePath, 'one', 'two', 'two.cxx'),
-      path.join(fixturePath, 'one', 'two', 'three', 'three.c++'),
+      path.join('test.c'),
+      path.join('main.cpp'),
+      path.join('main.cc'),
+      path.join('one', 'one.cc'),
+      path.join('one', 'two', 'two.cxx'),
+      path.join('one', 'two', 'three', 'three.c++'),
       // h* files
-      path.join(fixturePath, 'headers', 'test.h'),
-      path.join(fixturePath, 'headers', 'one', 'one.hh'),
-      path.join(fixturePath, 'headers', 'one', 'two', 'two.hxx'),
-      path.join(fixturePath, 'headers', 'one', 'two', 'three', 'three.h++'),
-      path.join(fixturePath, 'headers', 'main.hpp'),
+      path.join('headers', 'test.h'),
+      path.join('headers', 'one', 'one.hh'),
+      path.join('headers', 'one', 'two', 'two.hxx'),
+      path.join('headers', 'one', 'two', 'three', 'three.h++'),
+      path.join('headers', 'main.hpp'),
       // i* files
-      path.join(fixturePath, 'templates', 'test.i'),
-      path.join(fixturePath, 'templates', 'test.ii'),
-      path.join(fixturePath, 'templates', 'test.ipp'),
-      path.join(fixturePath, 'templates', 'test.ixx'),
+      path.join('templates', 'test.i'),
+      path.join('templates', 'test.ii'),
+      path.join('templates', 'test.ipp'),
+      path.join('templates', 'test.ixx'),
       // t* files
-      path.join(fixturePath, 'templates', 'test.txx'),
-      path.join(fixturePath, 'templates', 'test.tpp'),
-      path.join(fixturePath, 'templates', 'sub', 'test.tpl'),
+      path.join('templates', 'test.txx'),
+      path.join('templates', 'test.tpp'),
+      path.join('templates', 'sub', 'test.tpl'),
     ];
     expect(actual.sort()).toEqual(expected.sort());
   });

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -10,7 +10,7 @@ const helloWorldSignatures: Facts[] = [
     type: 'fileSignatures',
     data: [
       {
-        path: path.join(helloWorldFixturePath, 'add.cpp'),
+        path: 'add.cpp',
         hashes_ffm: [
           {
             format: 1,
@@ -19,7 +19,7 @@ const helloWorldSignatures: Facts[] = [
         ],
       },
       {
-        path: path.join(helloWorldFixturePath, 'add.h'),
+        path: 'add.h',
         hashes_ffm: [
           {
             format: 1,
@@ -28,7 +28,7 @@ const helloWorldSignatures: Facts[] = [
         ],
       },
       {
-        path: path.join(helloWorldFixturePath, 'main.cpp'),
+        path: 'main.cpp',
         hashes_ffm: [
           {
             format: 1,

--- a/test/signatures.test.ts
+++ b/test/signatures.test.ts
@@ -5,72 +5,84 @@ import { SignatureHashAlgorithm } from '../lib/types';
 describe('getSignature', () => {
   it('should return a correct scan result - dubhash', async () => {
     const fixturePath = path.join(__dirname, 'fixtures');
-    const filePath = path.join(fixturePath, 'example', 'main.cc');
+    const filePath = path.join('example', 'main.cc');
     const expected = [
       {
         path: filePath,
         hashes_ffm: [{ format: 1, data: 'WY0eT7ZYA9PlMPjm2oSZ2g' }],
       },
     ];
-    const actual = await getSignaturesByAlgorithm([filePath]);
+    const actual = await getSignaturesByAlgorithm(fixturePath, [filePath]);
     expect(actual).toStrictEqual(expected);
   });
 
   it('should return a correct scan result - uhash', async () => {
     const fixturePath = path.join(__dirname, 'fixtures');
-    const filePath = path.join(fixturePath, 'example', 'main.cc');
+    const filePath = path.join('example', 'main.cc');
     const expected = [
       {
         path: filePath,
         hashes_ffm: [{ format: 3, data: '15b464e1ed112524ebfae35b' }],
       },
     ];
-    const actual = await getSignaturesByAlgorithm([filePath], 'uhash');
+    const actual = await getSignaturesByAlgorithm(
+      fixturePath,
+      [filePath],
+      'uhash',
+    );
     expect(actual).toStrictEqual(expected);
   });
 
   it('should return null for empty file', async () => {
     const fixturePath = path.join(__dirname, 'fixtures');
-    const filePath = path.join(fixturePath, 'empty', '.keep');
-    const actual = await getSignaturesByAlgorithm([filePath]);
+    const filePath = path.join('empty', '.keep');
+    const actual = await getSignaturesByAlgorithm(fixturePath, [filePath]);
     expect(actual).toStrictEqual([null]);
   });
 
   it('binaryfile - dubhash', async () => {
     const fixturePath = path.join(__dirname, 'fixtures');
-    const filePath = path.join(fixturePath, 'dog.jpg');
+    const filePath = 'dog.jpg';
     const expected = [
       {
         path: filePath,
         hashes_ffm: [{ format: 1, data: 'lfDsE17jjwfgeFfW9pLWJQ' }],
       },
     ];
-    const actual = await getSignaturesByAlgorithm([filePath]);
+    const actual = await getSignaturesByAlgorithm(fixturePath, [filePath]);
     expect(actual).toStrictEqual(expected);
   });
 
   it('binaryfile - uhash', async () => {
     const fixturePath = path.join(__dirname, 'fixtures');
-    const filePath = path.join(fixturePath, 'dog.jpg');
+    const filePath = 'dog.jpg';
     const expected = [
       {
         path: filePath,
         hashes_ffm: [{ format: 3, data: '95f0ec135ee38f07e07857d6' }],
       },
     ];
-    const actual = await getSignaturesByAlgorithm([filePath], 'uhash');
+    const actual = await getSignaturesByAlgorithm(
+      fixturePath,
+      [filePath],
+      'uhash',
+    );
     expect(actual).toStrictEqual(expected);
   });
 
   it('should throw exception if unsupported hashType is specified', async () => {
     expect.assertions(1);
     const fixturePath = path.join(__dirname, 'fixtures');
-    const filePath = path.join(fixturePath, 'dog.jpg');
+    const filePath = 'dog.jpg';
     const expected = new Error('Unsupported hashType non-existing-hash-type');
     const invalidHashAlgorithmType = 'non-existing-hash-type' as SignatureHashAlgorithm;
     expect(
       async () =>
-        await getSignaturesByAlgorithm([filePath], invalidHashAlgorithmType),
+        await getSignaturesByAlgorithm(
+          fixturePath,
+          [filePath],
+          invalidHashAlgorithmType,
+        ),
     ).rejects.toThrow(expected);
   });
 });

--- a/test/signatures.test.ts
+++ b/test/signatures.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { getSignaturesByAlgorithm } from '../lib/signatures';
-import { SignatureHashAlgorithm } from '../lib/types';
+import { SignatureFormat } from '../lib/types';
 
 describe('getSignature', () => {
   it('should return a correct scan result - dubhash', async () => {
@@ -75,7 +75,7 @@ describe('getSignature', () => {
     const fixturePath = path.join(__dirname, 'fixtures');
     const filePath = 'dog.jpg';
     const expected = new Error('Unsupported hashType non-existing-hash-type');
-    const invalidHashAlgorithmType = 'non-existing-hash-type' as SignatureHashAlgorithm;
+    const invalidHashAlgorithmType = 'non-existing-hash-type' as SignatureFormat;
     expect(
       async () =>
         await getSignaturesByAlgorithm(


### PR DESCRIPTION
### refactor: clean up selection of hash algorithm

- Use an object to select signature format
- Align SAPI and Snyk terminology, using SignatureFormat
  instead of SignatureHashAlgorithm.