### PR TITLE
feat: display skipped files

### DIFF
--- a/lib/display/index.ts
+++ b/lib/display/index.ts
@@ -4,6 +4,7 @@ import { createFromJSON } from '@snyk/dep-graph';
 import { Options, ScanResult, TestResult } from '../types';
 import {
   displaySignatures,
+  displaySkippedFiles,
   selectDisplayStrategy,
   displayErrors,
 } from './display';
@@ -24,6 +25,10 @@ export async function display(
       const signatureLines = displaySignatures(scanResults);
       result.push(...signatureLines);
     }
+
+    const skippedFilesLines = displaySkippedFiles(scanResults, options);
+    result.push(...skippedFilesLines);
+
     for (const testResult of testResults) {
       const depGraph = createFromJSON(testResult.depGraphData);
       const [dependencySection, issuesSection] = selectDisplayStrategy(

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -39,6 +39,10 @@ export async function scan(options: Options): Promise<PluginResponse> {
       s.path = path.relative(options.path, s.path);
     });
 
+    skippedFiles.forEach((f) => {
+      f.path = path.relative(options.path, f.path);
+    });
+
     const end = Date.now();
     const totalMilliseconds = end - start;
 
@@ -54,6 +58,7 @@ export async function scan(options: Options): Promise<PluginResponse> {
 
     const facts: Facts[] = [
       { type: 'fileSignatures', data: filteredSignatures },
+      { type: 'skippedFiles', data: skippedFiles },
     ];
 
     const analytics: Analytics[] = [

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -23,8 +23,9 @@ export async function scan(options: Options): Promise<PluginResponse> {
     }
 
     const start = Date.now();
-    const filePaths = await find(options.path);
-    debug('%d files found \n', filePaths.length);
+    const { filePaths, skippedFiles } = await find(options.path);
+    debug('%d files found \n', filePaths.length + skippedFiles.length);
+    debug('%d files skipped \n', skippedFiles.length);
 
     const allSignatures: (SignatureResult | null)[] = await getSignaturesByAlgorithm(
       filePaths,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -47,6 +47,7 @@ export interface Options {
   projectName?: string;
   'print-deps'?: boolean;
   'print-dep-paths'?: boolean;
+  'print-skipped-unmanaged-files'?: boolean;
 }
 
 export type SignatureHashAlgorithm = 'dubhash' | 'uhash';

--- a/test/find.test.ts
+++ b/test/find.test.ts
@@ -32,7 +32,7 @@ describe('find', () => {
       path.join(fixturePath, 'templates', 'test.tpp'),
       path.join(fixturePath, 'templates', 'sub', 'test.tpl'),
     ];
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.filePaths.sort()).toEqual(expected.sort());
   });
 
   it('should produce an empty list when file path is invalid', async () => {

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -38,6 +38,10 @@ const helloWorldSignatures: Facts[] = [
       },
     ],
   },
+  {
+    data: [],
+    type: 'skippedFiles',
+  },
 ];
 
 const bigFixturePath = path.join(__dirname, 'fixtures', 'big-fixture');


### PR DESCRIPTION
Display and store skipped files as a fact, relative to the project.
The list enables us to track why some dependencies was not identified.

This is helpful, if we miss some dependency when running locally, or
if it's not identified when running a scheduled monitor.

Includes following changes:

- List first ten skipped files in display.ts, and the reason why it's skipped.
- A flag to toggle the list in display (--print-skipped-unmanaged-files)
- Sends skipped files to the registry

Ticket: TUN-96