### PR TITLE
fix: skip files greater than or equal to 2GB

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -1,0 +1,1 @@
+export const MAX_SUPPORTED_FILE_SIZE: number = 2 * 1024 * 1024 * 1024 - 1;

--- a/test/extract-file-paths.test.ts
+++ b/test/extract-file-paths.test.ts
@@ -1,0 +1,40 @@
+import { Stats } from 'fs';
+import * as findModule from '../lib/find';
+import { MAX_SUPPORTED_FILE_SIZE } from '../lib/common';
+
+describe('extract file paths', () => {
+  it('should skip files greater than 2GB', async () => {
+    const statSpy = jest.spyOn(findModule, 'stat');
+
+    const statWithAllowedFileSize = {
+      isFile: () => true,
+      isDirectory: () => false,
+      size: MAX_SUPPORTED_FILE_SIZE - 1,
+    } as Stats;
+
+    const statWithFileSizeGreaterThanMaxAllowed = {
+      isFile: () => true,
+      isDirectory: () => false,
+      size: MAX_SUPPORTED_FILE_SIZE + 1,
+    } as Stats;
+
+    statSpy.mockResolvedValueOnce(statWithAllowedFileSize);
+    statSpy.mockResolvedValueOnce(statWithFileSizeGreaterThanMaxAllowed);
+    statSpy.mockResolvedValueOnce(statWithAllowedFileSize);
+
+    const absolutePathWithAllowedFileSize = 'fake-proj/allowed-size.c';
+    const absolutePathThatExceedsMaxFileSize = 'fake-proj/exceeds-max-size.c';
+
+    const result = await findModule.extractFilePaths([
+      absolutePathWithAllowedFileSize,
+      absolutePathThatExceedsMaxFileSize,
+      absolutePathWithAllowedFileSize,
+    ]);
+
+    const expected = [
+      absolutePathWithAllowedFileSize,
+      absolutePathWithAllowedFileSize,
+    ];
+    expect(result).toEqual(expected);
+  });
+});

--- a/test/find.test.ts
+++ b/test/find.test.ts
@@ -1,11 +1,26 @@
-import * as path from 'path';
+import { Stats } from 'fs';
 
-import { find } from '../lib/find';
+import * as path from 'path';
+import * as findModule from '../lib/find';
 
 describe('find', () => {
+  it('find should throw if dirStat is not a directory', async () => {
+    const statSpy = jest.spyOn(findModule, 'stat');
+    const statIsNotDirectory = {
+      isFile: () => true,
+      isDirectory: () => false,
+      size: 0,
+    } as Stats;
+
+    statSpy.mockResolvedValueOnce(statIsNotDirectory);
+    await expect(findModule.find('workspace')).rejects.toThrow(
+      'workspace is not a directory',
+    );
+  });
+
   it('should produce list of files found in directory', async () => {
     const fixturePath = path.join(__dirname, 'fixtures', 'example');
-    const actual = await find(fixturePath);
+    const actual = await findModule.find(fixturePath);
     const expected = [
       // md file
       path.join(fixturePath, 'README.md'),
@@ -38,7 +53,7 @@ describe('find', () => {
   it('should produce an empty list when file path is invalid', async () => {
     const filePath = 'path/does/not/exist';
     try {
-      await find(filePath);
+      await findModule.find(filePath);
     } catch (err) {
       expect(err).toEqual(
         expect.objectContaining({
@@ -54,7 +69,7 @@ describe('find', () => {
     const fixturePath = path.join(__dirname, 'fixtures', 'example', 'main.cpp');
     const expected = new Error(`${fixturePath} is not a directory`);
     try {
-      await find(fixturePath);
+      await findModule.find(fixturePath);
     } catch (err) {
       expect(err).toEqual(expected);
     }


### PR DESCRIPTION
Due to limitations with nodes Buffer, we agreed
to skip files greater than or equal to 2GB.

This is implemented by following changes:

- Add file size validation to find.ts

Ticket: TUN-96