### PR TITLE
Feat: show confidence score

### DIFF
--- a/lib/display/common.ts
+++ b/lib/display/common.ts
@@ -19,6 +19,6 @@ export function getColorBySeverity(severity: string): chalk.Chalk {
   }
 }
 
-export function capitalize(str: string) {
+export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -72,6 +72,14 @@ export interface TestResult {
   issuesData: IssuesData;
   depGraphData: DepGraphData;
   depsFilePaths?: DepsFilePaths;
+  fileSignaturesDetails?: FileSignaturesDetails;
+}
+
+export interface FileSignaturesDetails {
+  [pkgKey: string]: {
+    confidence: number;
+    filePaths: string[];
+  };
 }
 
 export interface SignatureResult {

--- a/lib/utils/object.ts
+++ b/lib/utils/object.ts
@@ -1,0 +1,3 @@
+export function isEmpty(obj: Record<string, unknown>): boolean {
+  return obj && Object.keys(obj).length === 0;
+}

--- a/test/utils/object.test.ts
+++ b/test/utils/object.test.ts
@@ -1,0 +1,11 @@
+import { isEmpty } from '../../lib/utils/object';
+
+describe('isEmpty', () => {
+  it('should return false when objects that have at least 1 key are passed in', () => {
+    expect(isEmpty({ foo: 'bar' })).toBe(false);
+  });
+
+  it('should return true when empty objects are passed in ', () => {
+    expect(isEmpty({})).toBe(true);
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

The purpose of those changes are related to the addition of a new field in the CLI output for the unmanaged flows.

When using either `--print-deps` or `--print-dep-paths` args along with the `unmanaged scan` command on the CLI you should be able to see the confidence score of the found dependencies.