### PR TITLE
fix: align package id creation to mirror the server logic

### DIFF
--- a/lib/display/display.ts
+++ b/lib/display/display.ts
@@ -83,12 +83,12 @@ export function displayDependencies(
 
   result.push(chalk.whiteBright('\nDependencies:\n'));
   for (const { name, version } of dependencies) {
-    const dependencyId = `${name}@${version}`;
+    const dependencyId = `${name}@${version}`.toLowerCase();
     result.push(`\n${leftPad(dependencyId, 2)}`);
 
     if (
       fileSignaturesDetails &&
-      fileSignaturesDetails[dependencyId].confidence
+      fileSignaturesDetails[dependencyId]?.confidence
     ) {
       result.push(
         leftPad(


### PR DESCRIPTION
On the server side, when we construct the package id we
make the output lower cased (check: https://github.com/snyk/registry/blob/main/src/lib/fossid-to-snyk/index.ts#L283). 
We need to align also the
client to mirror that logic in order to succesfully
find and extract the required data.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team
