### PR TITLE
fix: exit status codes

### DIFF
--- a/lib/display/display.ts
+++ b/lib/display/display.ts
@@ -44,7 +44,7 @@ function findDependencyLines(
     return displayDependencies(depGraph, fileSignaturesDetails);
   }
 
-  return [''];
+  return [];
 }
 
 export function selectDisplayStrategy(
@@ -196,14 +196,9 @@ export function displayIssues(
     : chalk.greenBright(issuesCount);
 
   const identifiedUnmanagedDeps = `Tested ${dependenciesCountMsg} for known issues, found ${issuesFound}.\n`;
-  const failedToIdentifyUnmanagedDeps = `Could not identify unmanaged dependencies to be tested.`;
-
-  const endlineMsg =
-    dependencies?.length > 0
-      ? identifiedUnmanagedDeps
-      : failedToIdentifyUnmanagedDeps;
-
-  result.push(endlineMsg);
+  if (dependencies?.length > 0) {
+    result.push(identifiedUnmanagedDeps);
+  }
 
   return result;
 }

--- a/lib/display/index.ts
+++ b/lib/display/index.ts
@@ -3,10 +3,11 @@ import { debug } from '../debug';
 import { createFromJSON } from '@snyk/dep-graph';
 import { Options, ScanResult, TestResult } from '../types';
 import {
+  displayErrors,
   displaySignatures,
   selectDisplayStrategy,
-  displayErrors,
 } from './display';
+import { ExitCode, exitWith } from '../utils/error';
 
 export async function display(
   scanResults: ScanResult[],
@@ -14,16 +15,25 @@ export async function display(
   errors: string[],
   options?: Options,
 ): Promise<string> {
+  if (errors.length > 0) {
+    exitWith(ExitCode.Error, displayErrors(errors).join('\n'));
+  }
+
+  const result: string[] = [];
+  let hasDependencies = false;
+  let hasVulnerabilities = false;
+
   try {
-    const result: string[] = [];
     if (options?.path) {
       const prefix = chalk.bold.white(`\nTesting ${options.path}...\n`);
       result.push(prefix);
     }
+
     if (options?.debug) {
       const signatureLines = displaySignatures(scanResults);
       result.push(...signatureLines);
     }
+
     for (const testResult of testResults) {
       const depGraph = createFromJSON(testResult.depGraphData);
       const [dependencySection, issuesSection] = selectDisplayStrategy(
@@ -32,13 +42,29 @@ export async function display(
         testResult,
       );
 
+      if (testResult.depGraphData.pkgs.length > 1) {
+        hasDependencies = true;
+      }
+
+      if (testResult.issues.length > 0) {
+        hasVulnerabilities = true;
+      }
+
       result.push(...dependencySection, ...issuesSection);
     }
-    const errorLines = displayErrors(errors);
-    result.push(...errorLines);
-    return result.join('\n');
   } catch (error) {
-    debug(error.message || 'Error displaying results. ' + error);
-    return 'Error displaying results.';
+    debug(error.message || `Error displaying the results: ${error}`);
+    exitWith(ExitCode.Error, 'Error displaying results.');
   }
+
+  if (hasVulnerabilities) {
+    exitWith(ExitCode.VulnerabilitiesFound, result.join('\n'));
+  }
+
+  if (!hasDependencies) {
+    result.push(`Could not detect supported target files in ${options?.path}`);
+    exitWith(ExitCode.NoSupportedFiles, result.join('\n'));
+  }
+
+  return result.join('\n');
 }

--- a/lib/utils/error.ts
+++ b/lib/utils/error.ts
@@ -1,0 +1,13 @@
+export enum ExitCode {
+  VulnerabilitiesFound = 'VULNS',
+  Error = 2,
+  NoSupportedFiles = 3,
+}
+
+export function exitWith(exitCode: ExitCode, message: string): void {
+  const err = new Error() as any;
+  err.message = message;
+  err.code = exitCode.valueOf();
+
+  throw err;
+}

--- a/test/display.test.ts
+++ b/test/display.test.ts
@@ -11,6 +11,7 @@ import {
   noDepOrIssues,
 } from './fixtures/hello-world-display/test-results';
 import { isWindowsOS } from '../lib/common';
+import { ExitCode } from '../lib/utils/error';
 
 const helloWorldPath = path.join('test', 'fixtures', 'hello-world');
 
@@ -18,12 +19,17 @@ describe('display', () => {
   it('should return expected text for one dependency, three issues, no errors', async () => {
     const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [];
-    const actual = await display(scanResults, withDepThreeIssues, errors);
     const expected = await readFixture(
       'hello-world-display',
       'display-one-dep-three-issues-no-errors.txt',
     );
-    expect(stripAnsi(actual)).toEqual(stripAnsi(expected));
+
+    try {
+      await display(scanResults, withDepThreeIssues, errors);
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.VulnerabilitiesFound);
+      expect(stripAnsi(error.message)).toEqual(stripAnsi(expected));
+    }
   });
 
   it('should return expected text for one dependency, three issues (using https://security.snyk.io/), no errors using', async () => {
@@ -34,41 +40,46 @@ describe('display', () => {
       path,
       supportUnmanagedVulnDB: true,
     };
-    const actual = await display(
-      scanResults,
-      withDepThreeIssues,
-      errors,
-      options,
-    );
-
     const osName = isWindowsOS() ? 'windows' : 'unix';
     const expected = await readFixture(
       'display-snyk-security-details-url',
       `one-dep-three-issues-no-errors-${osName}.txt`,
     );
-    expect(stripAnsi(actual)).toEqual(stripAnsi(expected));
+
+    try {
+      await display(scanResults, withDepThreeIssues, errors, options);
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.VulnerabilitiesFound);
+      expect(stripAnsi(error.message)).toEqual(stripAnsi(expected));
+    }
   });
 
   it('should return expected text when one dependency, no issues, no errors', async () => {
     const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [];
-    const actual = await display(scanResults, withDepNoIssues, errors);
     const expected = await readFixture(
       'hello-world-display',
       'display-one-dep-no-issues-no-errors.txt',
     );
-    expect(stripAnsi(actual)).toEqual(stripAnsi(expected));
+
+    const result = await display(scanResults, withDepNoIssues, errors);
+    expect(stripAnsi(result)).toEqual(stripAnsi(expected));
   });
 
   it('should return expected text when no dependencies, no issues, no errors', async () => {
     const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [];
-    const actual = await display(scanResults, noDepOrIssues, errors);
     const expected = await readFixture(
       'hello-world-display',
-      'display-no-deps-no-issues-no-errors.txt',
+      'display-no-scan-results.txt',
     );
-    expect(stripAnsi(actual)).toEqual(stripAnsi(expected));
+
+    try {
+      await display(scanResults, noDepOrIssues, errors);
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.NoSupportedFiles);
+      expect(stripAnsi(error.message)).toContain(stripAnsi(expected));
+    }
   });
 
   it('should return expected text string when no projects', async () => {
@@ -78,8 +89,13 @@ describe('display', () => {
       'hello-world-display',
       'display-no-scan-results.txt',
     );
-    const actual = await display(scanResult, noDepOrIssues, errors);
-    expect(stripAnsi(actual)).toEqual(stripAnsi(expected));
+
+    try {
+      await display(scanResult, noDepOrIssues, errors);
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.NoSupportedFiles);
+      expect(stripAnsi(error.message)).toContain(stripAnsi(expected));
+    }
   });
 
   it('should return expected text string when invalid projects', async () => {
@@ -88,8 +104,13 @@ describe('display', () => {
       'hello-world-display',
       'display-no-scan-results.txt',
     );
-    const actual = await display([1, 2, 3] as any, noDepOrIssues, errors);
-    expect(stripAnsi(actual)).toEqual(stripAnsi(expected));
+
+    try {
+      await display([1, 2, 3] as any, noDepOrIssues, errors);
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.NoSupportedFiles);
+      expect(stripAnsi(error.message)).toContain(stripAnsi(expected));
+    }
   });
 
   it('should return expected text when invalid artifacts', async () => {
@@ -98,12 +119,17 @@ describe('display', () => {
       'hello-world-display',
       'display-no-scan-results.txt',
     );
-    const actual = await display(
-      [{ artifacts: ['a', 'b', 'c'] }] as any,
-      noDepOrIssues,
-      errors,
-    );
-    expect(stripAnsi(actual)).toEqual(stripAnsi(expected));
+
+    try {
+      await display(
+        [{ artifacts: ['a', 'b', 'c'] }] as any,
+        noDepOrIssues,
+        errors,
+      );
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.NoSupportedFiles);
+      expect(stripAnsi(error.message)).toContain(stripAnsi(expected));
+    }
   });
 
   it('should return expected text when invalid artifact data', async () => {
@@ -112,82 +138,108 @@ describe('display', () => {
       'hello-world-display',
       'display-no-scan-results.txt',
     );
-    const actual = await display(
-      [{ artifacts: [{ type: 'test', data: [1, 2, 3] }] }] as any,
-      noDepOrIssues,
-      errors,
-    );
-    expect(stripAnsi(actual)).toEqual(stripAnsi(expected));
+
+    try {
+      await display(
+        [{ artifacts: [{ type: 'test', data: [1, 2, 3] }] }] as any,
+        noDepOrIssues,
+        errors,
+      );
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.NoSupportedFiles);
+      expect(stripAnsi(error.message)).toContain(stripAnsi(expected));
+    }
   });
 
-  it('should return expected text for one dependency, one issue, one error', async () => {
+  it('should return expected text for error', async () => {
     const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [
       'Could not test dependencies in test/fixtures/invalid',
     ];
-    const actual = await display(scanResults, withDepOneIssueAndFix, errors);
     const expected = await readFixture(
       'hello-world-display',
       'display-one-dep-one-issue-one-error.txt',
     );
-    expect(stripAnsi(actual)).toEqual(stripAnsi(expected));
+
+    try {
+      await display(scanResults, withDepOneIssueAndFix, errors);
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.Error);
+      expect(stripAnsi(error.message)).toEqual(stripAnsi(expected));
+    }
   });
 
-  it('should return expected text for one dependency, one issue (using https://security.snyk.io/), one error', async () => {
+  it('should return expected text for one dependency, one issue (using https://security.snyk.io/)', async () => {
     const path = helloWorldPath;
     const { scanResults } = await scan({ path });
-    const errors: string[] = [
-      'Could not test dependencies in test/fixtures/invalid',
-    ];
     const options: Options = {
       path,
       supportUnmanagedVulnDB: true,
     };
-
-    const actual = await display(
-      scanResults,
-      withDepOneIssueAndFix,
-      errors,
-      options,
-    );
-
     const osName = isWindowsOS() ? 'windows' : 'unix';
     const expected = await readFixture(
       'display-snyk-security-details-url',
       `one-dep-one-issue-one-error-${osName}.txt`,
     );
 
-    expect(stripAnsi(actual)).toEqual(stripAnsi(expected));
+    try {
+      await display(scanResults, withDepOneIssueAndFix, [], options);
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.VulnerabilitiesFound);
+      expect(stripAnsi(error.message)).toEqual(stripAnsi(expected));
+    }
   });
 
-  it('should return expected text for one dependency, no issues, two errors', async () => {
+  it('should return expected text for two errors', async () => {
     const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [
       'Could not test dependencies in test/fixtures/invalid1',
       'Could not test dependencies in test/fixtures/invalid2',
     ];
-    const actual = await display(scanResults, withDepNoIssues, errors);
     const expected = await readFixture(
       'hello-world-display',
       'display-one-dep-no-issues-two-errors.txt',
     );
-    expect(stripAnsi(actual)).toEqual(stripAnsi(expected));
+
+    try {
+      await display(scanResults, withDepNoIssues, errors);
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.Error);
+      expect(stripAnsi(error.message)).toEqual(stripAnsi(expected));
+    }
   });
 
   it('should show test path in output if path present', async () => {
     const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [];
     const options = { path: '/path/to/project' };
-    const actual = await display(
-      scanResults,
-      withDepOneIssueAndFix,
-      errors,
-      options,
-    );
     const expected = await readFixture(
       'hello-world-display',
       'display-testing-file-path.txt',
     );
-    expect(stripAnsi(actual)).toEqual(expected);
+
+    try {
+      await display(scanResults, withDepOneIssueAndFix, errors, options);
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.VulnerabilitiesFound);
+      expect(stripAnsi(error.message)).toEqual(stripAnsi(expected));
+    }
+  });
+
+  it('should show return success without any error being thrown', async () => {
+    const { scanResults } = await scan({ path: helloWorldPath });
+    const errors: string[] = [];
+    const options = { path: '/path/to/project' };
+    const expected = await readFixture(
+      'hello-world-display',
+      'display-testing-file-path.txt',
+    );
+
+    try {
+      await display(scanResults, withDepOneIssueAndFix, errors, options);
+    } catch (error) {
+      expect(stripAnsi(error.code)).toEqual(ExitCode.VulnerabilitiesFound);
+      expect(stripAnsi(error.message)).toEqual(stripAnsi(expected));
+    }
   });
 });

--- a/test/fixtures/display-snyk-security-details-url/one-dep-one-issue-one-error-unix.txt
+++ b/test/fixtures/display-snyk-security-details-url/one-dep-one-issue-one-error-unix.txt
@@ -1,7 +1,6 @@
 
 Testing test/fixtures/hello-world...
 
-
 [97mIssues:[39m
 [93m[39m
 [93m ✗ [Medium] Cross-site Scripting (XSS)[39m
@@ -9,6 +8,3 @@ Testing test/fixtures/hello-world...
     URL: https://security.snyk.io/vuln/cpp:hello-world:20161130
 
 Tested 1 dependency for known issues, found [91m1 issue[39m.
-
-[91mErrors[39m
-Could not test dependencies in test/fixtures/invalid

--- a/test/fixtures/display-snyk-security-details-url/one-dep-one-issue-one-error-windows.txt
+++ b/test/fixtures/display-snyk-security-details-url/one-dep-one-issue-one-error-windows.txt
@@ -1,7 +1,6 @@
 
 Testing test\fixtures\hello-world...
 
-
 [97mIssues:[39m
 [93m[39m
 [93m ✗ [Medium] Cross-site Scripting (XSS)[39m
@@ -9,6 +8,3 @@ Testing test\fixtures\hello-world...
     URL: https://security.snyk.io/vuln/cpp:hello-world:20161130
 
 Tested 1 dependency for known issues, found [91m1 issue[39m.
-
-[91mErrors[39m
-Could not test dependencies in test/fixtures/invalid

--- a/test/fixtures/display-snyk-security-details-url/one-dep-three-issues-no-errors-unix.txt
+++ b/test/fixtures/display-snyk-security-details-url/one-dep-three-issues-no-errors-unix.txt
@@ -1,7 +1,6 @@
 
 Testing test/fixtures/hello-world...
 
-
 [97mIssues:[39m
 [91m[39m
 [91m ✗ [High] Information Exposure[39m

--- a/test/fixtures/display-snyk-security-details-url/one-dep-three-issues-no-errors-windows.txt
+++ b/test/fixtures/display-snyk-security-details-url/one-dep-three-issues-no-errors-windows.txt
@@ -1,7 +1,6 @@
 
 Testing test\fixtures\hello-world...
 
-
 [97mIssues:[39m
 [91m[39m
 [91m ✗ [High] Information Exposure[39m

--- a/test/fixtures/hello-world-display/display-no-deps-no-issues-no-errors.txt
+++ b/test/fixtures/hello-world-display/display-no-deps-no-issues-no-errors.txt
@@ -1,2 +1,0 @@
-
-Could not identify unmanaged dependencies to be tested.

--- a/test/fixtures/hello-world-display/display-no-scan-results.txt
+++ b/test/fixtures/hello-world-display/display-no-scan-results.txt
@@ -1,2 +1,1 @@
-
-Could not identify unmanaged dependencies to be tested.
+Could not detect supported target files in

--- a/test/fixtures/hello-world-display/display-one-dep-no-issues-no-errors.txt
+++ b/test/fixtures/hello-world-display/display-one-dep-no-issues-no-errors.txt
@@ -1,2 +1,1 @@
-
 Tested 1 dependency for known issues, found [92m0 issues[39m.

--- a/test/fixtures/hello-world-display/display-one-dep-no-issues-two-errors.txt
+++ b/test/fixtures/hello-world-display/display-one-dep-no-issues-two-errors.txt
@@ -1,6 +1,3 @@
-
-Tested 1 dependency for known issues, found [92m0 issues[39m.
-
 [91mErrors[39m
 Could not test dependencies in test/fixtures/invalid1
 Could not test dependencies in test/fixtures/invalid2

--- a/test/fixtures/hello-world-display/display-one-dep-one-issue-one-error.txt
+++ b/test/fixtures/hello-world-display/display-one-dep-one-issue-one-error.txt
@@ -1,11 +1,2 @@
-
-[97mIssues:[39m
-[93m[39m
-[93m ✗ [Medium] Cross-site Scripting (XSS)[39m
-    Introduced through: hello-world@1.2.3
-    URL: https://nvd.nist.gov/vuln/detail/cpp:hello-world:20161130
-
-Tested 1 dependency for known issues, found [91m1 issue[39m.
-
 [91mErrors[39m
 Could not test dependencies in test/fixtures/invalid

--- a/test/fixtures/hello-world-display/display-one-dep-three-issues-no-errors.txt
+++ b/test/fixtures/hello-world-display/display-one-dep-three-issues-no-errors.txt
@@ -1,4 +1,3 @@
-
 [97mIssues:[39m
 [91m[39m
 [91m ✗ [High] Information Exposure[39m

--- a/test/fixtures/hello-world-display/display-testing-file-path.txt
+++ b/test/fixtures/hello-world-display/display-testing-file-path.txt
@@ -1,7 +1,6 @@
 
 Testing /path/to/project...
 
-
 Issues:
 
  ✗ [Medium] Cross-site Scripting (XSS)

--- a/test/utils/error.test.ts
+++ b/test/utils/error.test.ts
@@ -1,0 +1,33 @@
+import { ExitCode, exitWith } from '../../lib/utils/error';
+
+describe('exitWith', () => {
+  it.each([
+    [
+      ExitCode.VulnerabilitiesFound,
+      'vulns found error',
+      createError(ExitCode.VulnerabilitiesFound, 'vulns found error'),
+    ],
+    [
+      ExitCode.Error,
+      'generic error',
+      createError(ExitCode.Error, 'generic error'),
+    ],
+    [
+      ExitCode.NoSupportedFiles,
+      'no supported files error',
+      createError(ExitCode.NoSupportedFiles, 'no supported files error'),
+    ],
+  ])('should return proper error', (exitCode, message, expected) => {
+    expect(() => {
+      exitWith(exitCode, message);
+    }).toThrow(expected);
+  });
+});
+
+function createError(exitCode: ExitCode, message: string) {
+  const err = new Error() as any;
+  err.message = message;
+  err.code = exitCode.valueOf();
+
+  return err;
+}


### PR DESCRIPTION
Align the cpp plugin in terms of returned status codes with the rest of the ecosystems.
The mechanism rely on exception throwing.
The Snyk CLI is capable of catching those exceptions and properly display the results.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

