### PR TITLE
fix: use correct casing for package IDs

### DIFF
--- a/lib/display/display.ts
+++ b/lib/display/display.ts
@@ -88,7 +88,7 @@ export function displayDependencies(
 
   result.push(chalk.whiteBright('\nDependencies:\n'));
   for (const { name, version } of dependencies) {
-    const dependencyId = `${name}@${version}`.toLowerCase();
+    const dependencyId = `${name}@${version}`;
     result.push(`\n${leftPad(dependencyId, 2)}`);
 
     if (


### PR DESCRIPTION
#### Bug fixes
  - broken --print-dep-paths
  - missing confidence level for some packages in the CLI

#### What does this PR do?

Current cpp-plugin make use of lower case for all characters in the package id.
This prevents the lookup for some customers and packages. It also prevented the
lookup of confidence-level shown in the CLI.
