### PR TITLE
fix: archive extraction depth

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -13,9 +13,9 @@ export const HASHING_CONCURRENCY_LEVEL = os.cpus().length;
 
 export const DECOMPRESSING_CONCURRENCY_LEVEL = os.cpus().length * 8;
 
-export const DEFAULT_DECOMPRESSING_DEPTH = 1;
+export const DECOMPRESSING_WORKSPACE_DIR = 'workspace';
 
-export const EXTRACTED_DIR_SUFFIX = '.extracted';
+export const DECOMPRESSING_IGNORE_DIR = 'ignore';
 
 export const isSupportedSize = (size: number): boolean =>
   0 < size && size < MAX_SUPPORTED_FILE_SIZE;

--- a/package.json
+++ b/package.json
@@ -30,13 +30,15 @@
   },
   "dependencies": {
     "@snyk/dep-graph": "^1.19.3",
+    "@types/uuid": "^8.3.4",
     "adm-zip": "^0.5.9",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",
     "hosted-git-info": "^3.0.7",
     "p-map": "^4.0.0",
     "tar": "^6.1.11",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/test/extract-file-paths.test.ts
+++ b/test/extract-file-paths.test.ts
@@ -35,7 +35,7 @@ describe('extract file paths', () => {
     statSpy.mockResolvedValueOnce(statWithFileSizeGreaterThanMaxAllowed);
     statSpy.mockResolvedValueOnce(statWithAllowedFileSize);
 
-    const result = await findModule.find(fixturePath);
+    const [result] = await findModule.find(fixturePath);
 
     const expected = [
       path.join(fixturePath, 'add.cpp'),

--- a/test/find.test.ts
+++ b/test/find.test.ts
@@ -6,7 +6,7 @@ import { promisify } from 'util';
 describe('find', () => {
   it('should produce list of files found in directory', async () => {
     const fixturePath = path.join(__dirname, 'fixtures', 'example');
-    const actual = await findModule.find(fixturePath);
+    const [actual] = await findModule.find(fixturePath);
     const expected = [
       // md file
       path.join(fixturePath, 'README.md'),
@@ -70,7 +70,7 @@ describe('find', () => {
 
     await promisify(fs.symlink)(symlinkTarget, symlinkPath, 'dir');
 
-    const actual = await findModule.find(fixturePath);
+    const [actual] = await findModule.find(fixturePath);
 
     expect(actual).toHaveLength(1);
     expect(actual).toEqual(expected);

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import { PluginResponse, scan } from '../lib';
 import { Facts } from '../lib/types';
-import { DEFAULT_DECOMPRESSING_DEPTH } from '../lib/common';
 
 const helloWorldFixturePath = join(__dirname, 'fixtures', 'hello-world');
 const helloWorldSignatures: Facts[] = [
@@ -147,7 +146,7 @@ describe('scan', () => {
     }
   });
 
-  it('should scan and extract tarballs', async () => {
+  it('should scan and extract tarballs with depth level 1 for a flat workspace', async () => {
     const fixturePath = join(
       __dirname,
       'fixtures',
@@ -156,7 +155,7 @@ describe('scan', () => {
       'tar',
     );
 
-    const actual = await scan({ path: fixturePath });
+    const actual = await scan({ path: fixturePath, 'max-depth': 1 });
     const expected: PluginResponse = {
       scanResults: [
         {
@@ -164,48 +163,6 @@ describe('scan', () => {
             {
               type: 'fileSignatures',
               data: [
-                {
-                  path: 'lib-a.tar',
-                  size: 2560,
-                  hashes_ffm: [
-                    {
-                      data: 'ddY4m4Sq6rC1co2FsCZ9Ng',
-                      format: 1,
-                    },
-                    {
-                      data: '75d6389b84aaeab0b5728d85',
-                      format: 3,
-                    },
-                  ],
-                },
-                {
-                  path: 'lib-b.tar.gz',
-                  size: 250,
-                  hashes_ffm: [
-                    {
-                      data: 'XyaldffaOsdBgrzR2O53ig',
-                      format: 1,
-                    },
-                    {
-                      data: '5f26a575f7da3ac74182bcd1',
-                      format: 3,
-                    },
-                  ],
-                },
-                {
-                  path: 'lib-c.tgz',
-                  size: 250,
-                  hashes_ffm: [
-                    {
-                      data: '8lGUJcUkXsVPo0MnvugbPA',
-                      format: 1,
-                    },
-                    {
-                      data: 'f2519425c5245ec54fa34327',
-                      format: 3,
-                    },
-                  ],
-                },
                 {
                   path: 'main.cpp',
                   size: 126,
@@ -277,7 +234,7 @@ describe('scan', () => {
             {
               name: 'fileSignaturesAnalyticsContext',
               data: {
-                totalFileSignatures: 7,
+                totalFileSignatures: 4,
                 totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
               },
             },
@@ -289,7 +246,7 @@ describe('scan', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should scan and extract zip archives', async () => {
+  it('should scan and extract zip archives with depth level 1 for a flat workspace', async () => {
     const fixturePath = join(
       __dirname,
       'fixtures',
@@ -298,7 +255,7 @@ describe('scan', () => {
       'zip',
     );
 
-    const actual = await scan({ path: fixturePath });
+    const actual = await scan({ path: fixturePath, 'max-depth': 1 });
     const expected: PluginResponse = {
       scanResults: [
         {
@@ -306,48 +263,6 @@ describe('scan', () => {
             {
               type: 'fileSignatures',
               data: [
-                {
-                  path: 'lib-a.zip',
-                  size: 429,
-                  hashes_ffm: [
-                    {
-                      data: 'Meh8ayPvHT6VuGKR5wjdXg',
-                      format: 1,
-                    },
-                    {
-                      data: '31e87c6b23ef1d3e95b86291',
-                      format: 3,
-                    },
-                  ],
-                },
-                {
-                  path: 'lib-b.zip',
-                  size: 429,
-                  hashes_ffm: [
-                    {
-                      data: '81lo+auqnFMCnqaU5szYXg',
-                      format: 1,
-                    },
-                    {
-                      data: 'f35968f9abaa9c53029ea694',
-                      format: 3,
-                    },
-                  ],
-                },
-                {
-                  path: 'lib-c.zip',
-                  size: 429,
-                  hashes_ffm: [
-                    {
-                      data: 'v8uyfCAxRngknfDtYACgNw',
-                      format: 1,
-                    },
-                    {
-                      data: 'bfcbb27c20314678249df0ed',
-                      format: 3,
-                    },
-                  ],
-                },
                 {
                   path: 'main.cpp',
                   size: 126,
@@ -419,7 +334,7 @@ describe('scan', () => {
             {
               name: 'fileSignaturesAnalyticsContext',
               data: {
-                totalFileSignatures: 7,
+                totalFileSignatures: 4,
                 totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
               },
             },
@@ -431,7 +346,7 @@ describe('scan', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should scan and extract tarballs with default recursion level', async () => {
+  it('should scan and extract tarballs with depth level of 1 for a nested workspace', async () => {
     const fixturePath = join(
       __dirname,
       'fixtures',
@@ -441,7 +356,7 @@ describe('scan', () => {
       'tar',
     );
 
-    const actual = await scan({ path: fixturePath });
+    const actual = await scan({ path: fixturePath, 'max-depth': 1 });
     const expected: PluginResponse = {
       scanResults: [
         {
@@ -449,20 +364,6 @@ describe('scan', () => {
             {
               type: 'fileSignatures',
               data: [
-                {
-                  path: 'deps.tar.gz',
-                  size: 1321,
-                  hashes_ffm: [
-                    {
-                      data: 'fz4RzoWgsBMUSljtF3vdLQ',
-                      format: 1,
-                    },
-                    {
-                      data: '7f3e11ce85a0b013144a58ed',
-                      format: 3,
-                    },
-                  ],
-                },
                 {
                   path: 'main.cpp',
                   size: 126,
@@ -506,7 +407,7 @@ describe('scan', () => {
             {
               name: 'fileSignaturesAnalyticsContext',
               data: {
-                totalFileSignatures: 3,
+                totalFileSignatures: 2,
                 totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
               },
             },
@@ -516,10 +417,9 @@ describe('scan', () => {
     };
 
     expect(actual).toEqual(expected);
-    expect(DEFAULT_DECOMPRESSING_DEPTH).toEqual(1);
   });
 
-  it('should scan and extract zip archives with default recursion level', async () => {
+  it('should scan and extract zip archives with depth level of 1 for a nested workspace', async () => {
     const fixturePath = join(
       __dirname,
       'fixtures',
@@ -529,7 +429,7 @@ describe('scan', () => {
       'zip',
     );
 
-    const actual = await scan({ path: fixturePath });
+    const actual = await scan({ path: fixturePath, 'max-depth': 1 });
     const expected: PluginResponse = {
       scanResults: [
         {
@@ -537,20 +437,6 @@ describe('scan', () => {
             {
               type: 'fileSignatures',
               data: [
-                {
-                  path: 'deps.zip',
-                  size: 2575,
-                  hashes_ffm: [
-                    {
-                      data: 'VsdARlgcIaJaG2oYnPvYlg',
-                      format: 1,
-                    },
-                    {
-                      data: '56c74046581c21a25a1b6a18',
-                      format: 3,
-                    },
-                  ],
-                },
                 {
                   path: 'main.cpp',
                   size: 126,
@@ -594,7 +480,7 @@ describe('scan', () => {
             {
               name: 'fileSignaturesAnalyticsContext',
               data: {
-                totalFileSignatures: 3,
+                totalFileSignatures: 2,
                 totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
               },
             },
@@ -604,10 +490,9 @@ describe('scan', () => {
     };
 
     expect(actual).toEqual(expected);
-    expect(DEFAULT_DECOMPRESSING_DEPTH).toEqual(1);
   });
 
-  it('should scan and extract both tarball & zip archives with default recursion', async () => {
+  it('should scan and extract both tarball & zip archives with depth level of 1 for a nested workspace', async () => {
     const fixturePath = join(
       __dirname,
       'fixtures',
@@ -616,14 +501,14 @@ describe('scan', () => {
       '3-levels',
     );
 
-    const actual = await scan({ path: fixturePath });
+    const actual = await scan({ path: fixturePath, 'max-depth': 1 });
     const expected: PluginResponse = {
       scanResults: [
         {
           analytics: [
             {
               data: {
-                totalFileSignatures: 6,
+                totalFileSignatures: 4,
                 totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
               },
               name: 'fileSignaturesAnalyticsContext',
@@ -632,20 +517,6 @@ describe('scan', () => {
           facts: [
             {
               data: [
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'fz4RzoWgsBMUSljtF3vdLQ',
-                      format: 1,
-                    },
-                    {
-                      data: '7f3e11ce85a0b013144a58ed',
-                      format: 3,
-                    },
-                  ],
-                  path: join('tar', 'deps.tar.gz'),
-                  size: 1321,
-                },
                 {
                   hashes_ffm: [
                     {
@@ -659,20 +530,6 @@ describe('scan', () => {
                   ],
                   path: join('tar', 'main.cpp'),
                   size: 126,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'VsdARlgcIaJaG2oYnPvYlg',
-                      format: 1,
-                    },
-                    {
-                      data: '56c74046581c21a25a1b6a18',
-                      format: 3,
-                    },
-                  ],
-                  path: join('zip', 'deps.zip'),
-                  size: 2575,
                 },
                 {
                   hashes_ffm: [
@@ -735,7 +592,7 @@ describe('scan', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should scan and extract both tarball & zip tarballs with specified recursion level', async () => {
+  it('should scan and extract both tarball & zip tarballs with specified depth level', async () => {
     const fixturePath = join(
       __dirname,
       'fixtures',
@@ -754,7 +611,7 @@ describe('scan', () => {
           analytics: [
             {
               data: {
-                totalFileSignatures: 8,
+                totalFileSignatures: 4,
                 totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
               },
               name: 'fileSignaturesAnalyticsContext',
@@ -763,20 +620,6 @@ describe('scan', () => {
           facts: [
             {
               data: [
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'fz4RzoWgsBMUSljtF3vdLQ',
-                      format: 1,
-                    },
-                    {
-                      data: '7f3e11ce85a0b013144a58ed',
-                      format: 3,
-                    },
-                  ],
-                  path: join('tar', 'deps.tar.gz'),
-                  size: 1321,
-                },
                 {
                   hashes_ffm: [
                     {
@@ -794,20 +637,6 @@ describe('scan', () => {
                 {
                   hashes_ffm: [
                     {
-                      data: 'VsdARlgcIaJaG2oYnPvYlg',
-                      format: 1,
-                    },
-                    {
-                      data: '56c74046581c21a25a1b6a18',
-                      format: 3,
-                    },
-                  ],
-                  path: join('zip', 'deps.zip'),
-                  size: 2575,
-                },
-                {
-                  hashes_ffm: [
-                    {
                       data: 'rTNlszcO9rHD53j4dQVfGQ',
                       format: 1,
                     },
@@ -818,20 +647,6 @@ describe('scan', () => {
                   ],
                   path: join('zip', 'main.cpp'),
                   size: 126,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'H7WP+tRggklZl5c/aKWXjA',
-                      format: 1,
-                    },
-                    {
-                      data: '1fb58ffad46082495997973f',
-                      format: 3,
-                    },
-                  ],
-                  path: join('deps.tar.gz', 'vendor', 'deps.tar.gz'),
-                  size: 1098,
                 },
                 {
                   hashes_ffm: [
@@ -852,20 +667,6 @@ describe('scan', () => {
                     'deps.tar.gz',
                   ),
                   size: 892,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'AWBkuX+tVWtOmeOsNeDOVw',
-                      format: 1,
-                    },
-                    {
-                      data: '016064b97fad556b4e99e3ac',
-                      format: 3,
-                    },
-                  ],
-                  path: join('deps.zip', 'vendor', 'deps.zip'),
-                  size: 2253,
                 },
                 {
                   hashes_ffm: [
@@ -899,6 +700,213 @@ describe('scan', () => {
             branch: expect.any(String),
             remoteUrl: expect.any(String),
           },
+        },
+      ],
+    };
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should scan and extract both tarball & zip tarballs with higher specified depth level', async () => {
+    const fixturePath = join(
+      __dirname,
+      'fixtures',
+      'extraction',
+      'nested',
+      '3-levels',
+    );
+
+    const actual = await scan({
+      path: fixturePath,
+      'max-depth': 3,
+    });
+    const expected: PluginResponse = {
+      scanResults: [
+        {
+          facts: [
+            {
+              type: 'fileSignatures',
+              data: [
+                {
+                  path: join('tar', 'main.cpp'),
+                  size: 126,
+                  hashes_ffm: [
+                    {
+                      data: 'rTNlszcO9rHD53j4dQVfGQ',
+                      format: 1,
+                    },
+                    {
+                      data: 'd7432de58aeeeea23d70d8ce',
+                      format: 3,
+                    },
+                  ],
+                },
+                {
+                  path: join('zip', 'main.cpp'),
+                  size: 126,
+                  hashes_ffm: [
+                    {
+                      data: 'rTNlszcO9rHD53j4dQVfGQ',
+                      format: 1,
+                    },
+                    {
+                      data: 'd7432de58aeeeea23d70d8ce',
+                      format: 3,
+                    },
+                  ],
+                },
+                {
+                  path: join(
+                    'deps.tar.gz',
+                    'vendor',
+                    'deps.tar.gz',
+                    'vendor',
+                    'deps.tar.gz',
+                    'vendor',
+                    'lib-a.tar',
+                  ),
+                  size: 2560,
+                  hashes_ffm: [
+                    {
+                      data: 'ddY4m4Sq6rC1co2FsCZ9Ng',
+                      format: 1,
+                    },
+                    {
+                      data: '75d6389b84aaeab0b5728d85',
+                      format: 3,
+                    },
+                  ],
+                },
+                {
+                  path: join(
+                    'deps.tar.gz',
+                    'vendor',
+                    'deps.tar.gz',
+                    'vendor',
+                    'deps.tar.gz',
+                    'vendor',
+                    'lib-b.tar.gz',
+                  ),
+                  size: 250,
+                  hashes_ffm: [
+                    {
+                      data: 'XyaldffaOsdBgrzR2O53ig',
+                      format: 1,
+                    },
+                    {
+                      data: '5f26a575f7da3ac74182bcd1',
+                      format: 3,
+                    },
+                  ],
+                },
+                {
+                  path: join(
+                    'deps.tar.gz',
+                    'vendor',
+                    'deps.tar.gz',
+                    'vendor',
+                    'deps.tar.gz',
+                    'vendor',
+                    'lib-c.tgz',
+                  ),
+                  size: 250,
+                  hashes_ffm: [
+                    {
+                      data: '8lGUJcUkXsVPo0MnvugbPA',
+                      format: 1,
+                    },
+                    {
+                      data: 'f2519425c5245ec54fa34327',
+                      format: 3,
+                    },
+                  ],
+                },
+                {
+                  path: join(
+                    'deps.zip',
+                    'vendor',
+                    'deps.zip',
+                    'vendor',
+                    'deps.zip',
+                    'vendor',
+                    'lib-a.zip',
+                  ),
+                  size: 429,
+                  hashes_ffm: [
+                    {
+                      data: 'Meh8ayPvHT6VuGKR5wjdXg',
+                      format: 1,
+                    },
+                    {
+                      data: '31e87c6b23ef1d3e95b86291',
+                      format: 3,
+                    },
+                  ],
+                },
+                {
+                  path: join(
+                    'deps.zip',
+                    'vendor',
+                    'deps.zip',
+                    'vendor',
+                    'deps.zip',
+                    'vendor',
+                    'lib-b.zip',
+                  ),
+                  size: 429,
+                  hashes_ffm: [
+                    {
+                      data: '81lo+auqnFMCnqaU5szYXg',
+                      format: 1,
+                    },
+                    {
+                      data: 'f35968f9abaa9c53029ea694',
+                      format: 3,
+                    },
+                  ],
+                },
+                {
+                  path: join(
+                    'deps.zip',
+                    'vendor',
+                    'deps.zip',
+                    'vendor',
+                    'deps.zip',
+                    'vendor',
+                    'lib-c.zip',
+                  ),
+                  size: 429,
+                  hashes_ffm: [
+                    {
+                      data: 'v8uyfCAxRngknfDtYACgNw',
+                      format: 1,
+                    },
+                    {
+                      data: 'bfcbb27c20314678249df0ed',
+                      format: 3,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          identity: {
+            type: 'cpp',
+          },
+          name: 'snyk-cpp-plugin',
+          target: {
+            remoteUrl: expect.any(String),
+            branch: expect.any(String),
+          },
+          analytics: [
+            {
+              name: 'fileSignaturesAnalyticsContext',
+              data: {
+                totalFileSignatures: 8,
+                totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
+              },
+            },
+          ],
         },
       ],
     };
@@ -922,61 +930,13 @@ describe('scan', () => {
     const expected: PluginResponse = {
       scanResults: [
         {
-          analytics: [
-            {
-              data: {
-                totalFileSignatures: 18,
-                totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
-              },
-              name: 'fileSignaturesAnalyticsContext',
-            },
-          ],
           facts: [
             {
+              type: 'fileSignatures',
               data: [
                 {
-                  hashes_ffm: [
-                    {
-                      data: 'H7WP+tRggklZl5c/aKWXjA',
-                      format: 1,
-                    },
-                    {
-                      data: '1fb58ffad46082495997973f',
-                      format: 3,
-                    },
-                  ],
-                  path: join('tar', 'deps.tar.gz'),
-                  size: 1098,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'rTNlszcO9rHD53j4dQVfGQ',
-                      format: 1,
-                    },
-                    {
-                      data: 'd7432de58aeeeea23d70d8ce',
-                      format: 3,
-                    },
-                  ],
                   path: join('tar', 'main.cpp'),
                   size: 126,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'AWBkuX+tVWtOmeOsNeDOVw',
-                      format: 1,
-                    },
-                    {
-                      data: '016064b97fad556b4e99e3ac',
-                      format: 3,
-                    },
-                  ],
-                  path: join('zip', 'deps.zip'),
-                  size: 2253,
-                },
-                {
                   hashes_ffm: [
                     {
                       data: 'rTNlszcO9rHD53j4dQVfGQ',
@@ -987,44 +947,10 @@ describe('scan', () => {
                       format: 3,
                     },
                   ],
+                },
+                {
                   path: join('zip', 'main.cpp'),
                   size: 126,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: '5lSqtn0msns07j/TQVjQjw',
-                      format: 1,
-                    },
-                    {
-                      data: 'e654aab67d26b27b34ee3fd3',
-                      format: 3,
-                    },
-                  ],
-                  path: join('deps.tar.gz', 'vendor', 'deps.tar.gz'),
-                  size: 892,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'ddY4m4Sq6rC1co2FsCZ9Ng',
-                      format: 1,
-                    },
-                    {
-                      data: '75d6389b84aaeab0b5728d85',
-                      format: 3,
-                    },
-                  ],
-                  path: join(
-                    'deps.tar.gz',
-                    'vendor',
-                    'deps.tar.gz',
-                    'vendor',
-                    'lib-a.tar',
-                  ),
-                  size: 2560,
-                },
-                {
                   hashes_ffm: [
                     {
                       data: 'rTNlszcO9rHD53j4dQVfGQ',
@@ -1035,6 +961,8 @@ describe('scan', () => {
                       format: 3,
                     },
                   ],
+                },
+                {
                   path: join(
                     'deps.tar.gz',
                     'vendor',
@@ -1045,28 +973,6 @@ describe('scan', () => {
                     'main.cpp',
                   ),
                   size: 126,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'XyaldffaOsdBgrzR2O53ig',
-                      format: 1,
-                    },
-                    {
-                      data: '5f26a575f7da3ac74182bcd1',
-                      format: 3,
-                    },
-                  ],
-                  path: join(
-                    'deps.tar.gz',
-                    'vendor',
-                    'deps.tar.gz',
-                    'vendor',
-                    'lib-b.tar.gz',
-                  ),
-                  size: 250,
-                },
-                {
                   hashes_ffm: [
                     {
                       data: 'rTNlszcO9rHD53j4dQVfGQ',
@@ -1077,6 +983,8 @@ describe('scan', () => {
                       format: 3,
                     },
                   ],
+                },
+                {
                   path: join(
                     'deps.tar.gz',
                     'vendor',
@@ -1087,28 +995,6 @@ describe('scan', () => {
                     'main.cpp',
                   ),
                   size: 126,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: '8lGUJcUkXsVPo0MnvugbPA',
-                      format: 1,
-                    },
-                    {
-                      data: 'f2519425c5245ec54fa34327',
-                      format: 3,
-                    },
-                  ],
-                  path: join(
-                    'deps.tar.gz',
-                    'vendor',
-                    'deps.tar.gz',
-                    'vendor',
-                    'lib-c.tgz',
-                  ),
-                  size: 250,
-                },
-                {
                   hashes_ffm: [
                     {
                       data: 'rTNlszcO9rHD53j4dQVfGQ',
@@ -1119,6 +1005,8 @@ describe('scan', () => {
                       format: 3,
                     },
                   ],
+                },
+                {
                   path: join(
                     'deps.tar.gz',
                     'vendor',
@@ -1129,42 +1017,6 @@ describe('scan', () => {
                     'main.cpp',
                   ),
                   size: 126,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'NafnlhdlUsoYOuZZdUgZ8Q',
-                      format: 1,
-                    },
-                    {
-                      data: '35a7e796176552ca183ae659',
-                      format: 3,
-                    },
-                  ],
-                  path: join('deps.zip', 'vendor', 'deps.zip'),
-                  size: 1931,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'Meh8ayPvHT6VuGKR5wjdXg',
-                      format: 1,
-                    },
-                    {
-                      data: '31e87c6b23ef1d3e95b86291',
-                      format: 3,
-                    },
-                  ],
-                  path: join(
-                    'deps.zip',
-                    'vendor',
-                    'deps.zip',
-                    'vendor',
-                    'lib-a.zip',
-                  ),
-                  size: 429,
-                },
-                {
                   hashes_ffm: [
                     {
                       data: 'rTNlszcO9rHD53j4dQVfGQ',
@@ -1175,6 +1027,8 @@ describe('scan', () => {
                       format: 3,
                     },
                   ],
+                },
+                {
                   path: join(
                     'deps.zip',
                     'vendor',
@@ -1185,28 +1039,6 @@ describe('scan', () => {
                     'main.cpp',
                   ),
                   size: 126,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: '81lo+auqnFMCnqaU5szYXg',
-                      format: 1,
-                    },
-                    {
-                      data: 'f35968f9abaa9c53029ea694',
-                      format: 3,
-                    },
-                  ],
-                  path: join(
-                    'deps.zip',
-                    'vendor',
-                    'deps.zip',
-                    'vendor',
-                    'lib-b.zip',
-                  ),
-                  size: 429,
-                },
-                {
                   hashes_ffm: [
                     {
                       data: 'rTNlszcO9rHD53j4dQVfGQ',
@@ -1217,6 +1049,8 @@ describe('scan', () => {
                       format: 3,
                     },
                   ],
+                },
+                {
                   path: join(
                     'deps.zip',
                     'vendor',
@@ -1227,28 +1061,6 @@ describe('scan', () => {
                     'main.cpp',
                   ),
                   size: 126,
-                },
-                {
-                  hashes_ffm: [
-                    {
-                      data: 'v8uyfCAxRngknfDtYACgNw',
-                      format: 1,
-                    },
-                    {
-                      data: 'bfcbb27c20314678249df0ed',
-                      format: 3,
-                    },
-                  ],
-                  path: join(
-                    'deps.zip',
-                    'vendor',
-                    'deps.zip',
-                    'vendor',
-                    'lib-c.zip',
-                  ),
-                  size: 429,
-                },
-                {
                   hashes_ffm: [
                     {
                       data: 'rTNlszcO9rHD53j4dQVfGQ',
@@ -1259,6 +1071,8 @@ describe('scan', () => {
                       format: 3,
                     },
                   ],
+                },
+                {
                   path: join(
                     'deps.zip',
                     'vendor',
@@ -1269,9 +1083,18 @@ describe('scan', () => {
                     'main.cpp',
                   ),
                   size: 126,
+                  hashes_ffm: [
+                    {
+                      data: 'rTNlszcO9rHD53j4dQVfGQ',
+                      format: 1,
+                    },
+                    {
+                      data: 'd7432de58aeeeea23d70d8ce',
+                      format: 3,
+                    },
+                  ],
                 },
               ],
-              type: 'fileSignatures',
             },
           ],
           identity: {
@@ -1279,9 +1102,18 @@ describe('scan', () => {
           },
           name: 'snyk-cpp-plugin',
           target: {
-            branch: expect.any(String),
             remoteUrl: expect.any(String),
+            branch: expect.any(String),
           },
+          analytics: [
+            {
+              name: 'fileSignaturesAnalyticsContext',
+              data: {
+                totalFileSignatures: 8,
+                totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
+              },
+            },
+          ],
         },
       ],
     };
@@ -1289,7 +1121,7 @@ describe('scan', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should throw an error when invalid recursion level is provided', async () => {
+  it('should throw an error when invalid depth level is provided', async () => {
     const fixturePath = join(
       __dirname,
       'fixtures',
@@ -1305,12 +1137,12 @@ describe('scan', () => {
       });
     } catch (err) {
       expect(err.message).toEqual(
-        'Could not scan C/C++ project: invalid options: --max-depth should be a positive number.',
+        'Could not scan C/C++ project: invalid options: --max-depth should be greater than or equal to 0.',
       );
     }
   });
 
-  it('should not do the extraction when a recursion level of 0 is provided', async () => {
+  it('should not do the extraction when no depth level is provided', async () => {
     const fixturePath = join(
       __dirname,
       'fixtures',
@@ -1319,7 +1151,7 @@ describe('scan', () => {
       '3-levels',
     );
 
-    const actual = await scan({ path: fixturePath, 'max-depth': 0 });
+    const actual = await scan({ path: fixturePath });
     const expected = {
       scanResults: [
         {
@@ -1327,20 +1159,6 @@ describe('scan', () => {
             {
               type: 'fileSignatures',
               data: [
-                {
-                  path: join('tar', 'deps.tar.gz'),
-                  size: 1321,
-                  hashes_ffm: [
-                    {
-                      data: 'fz4RzoWgsBMUSljtF3vdLQ',
-                      format: 1,
-                    },
-                    {
-                      data: '7f3e11ce85a0b013144a58ed',
-                      format: 3,
-                    },
-                  ],
-                },
                 {
                   path: join('tar', 'main.cpp'),
                   size: 126,
@@ -1356,20 +1174,6 @@ describe('scan', () => {
                   ],
                 },
                 {
-                  path: join('zip', 'deps.zip'),
-                  size: 2575,
-                  hashes_ffm: [
-                    {
-                      data: 'VsdARlgcIaJaG2oYnPvYlg',
-                      format: 1,
-                    },
-                    {
-                      data: '56c74046581c21a25a1b6a18',
-                      format: 3,
-                    },
-                  ],
-                },
-                {
                   path: join('zip', 'main.cpp'),
                   size: 126,
                   hashes_ffm: [
@@ -1379,6 +1183,34 @@ describe('scan', () => {
                     },
                     {
                       data: 'd7432de58aeeeea23d70d8ce',
+                      format: 3,
+                    },
+                  ],
+                },
+                {
+                  path: join('tar', 'deps.tar.gz'),
+                  size: 1321,
+                  hashes_ffm: [
+                    {
+                      data: 'fz4RzoWgsBMUSljtF3vdLQ',
+                      format: 1,
+                    },
+                    {
+                      data: '7f3e11ce85a0b013144a58ed',
+                      format: 3,
+                    },
+                  ],
+                },
+                {
+                  path: join('zip', 'deps.zip'),
+                  size: 2575,
+                  hashes_ffm: [
+                    {
+                      data: 'VsdARlgcIaJaG2oYnPvYlg',
+                      format: 1,
+                    },
+                    {
+                      data: '56c74046581c21a25a1b6a18',
                       format: 3,
                     },
                   ],


### PR DESCRIPTION
Refactor the archive extraction depth mechanism to not do extraction by default. 
Also, fix the logic of the temp folder creation and handling.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team