### PR TITLE
fix: add userMessage to thrown errors

### DIFF
--- a/lib/display/index.ts
+++ b/lib/display/index.ts
@@ -66,7 +66,11 @@ export async function display(
   if (!hasDependencies) {
     exitWith(
       ExitCode.NoSupportedFiles,
-      `${output}\nCould not detect supported target files in ${options?.path}`,
+      `${output}\nCould not detect supported target files in ${
+        options?.path
+      }\nPlease see our documentation for supported languages and target files: ${chalk.underline(
+        'https://snyk.co/udVgQ',
+      )} and make sure you are in the right directory.`,
     );
   }
 

--- a/lib/utils/error.ts
+++ b/lib/utils/error.ts
@@ -13,6 +13,7 @@ export function exitWith(
 ): void {
   const err = new Error() as any;
   err.message = message;
+  err.userMessage = message;
   err.code = exitCode.valueOf();
 
   if (0 < testResults.length) {

--- a/test/display.test.ts
+++ b/test/display.test.ts
@@ -118,6 +118,7 @@ describe('display', () => {
 
     expect(errorReceived.code).toEqual(ExitCode.NoSupportedFiles);
     expect(stripAnsi(errorReceived.message)).toContain(stripAnsi(expected));
+    expect(stripAnsi(errorReceived.userMessage)).toContain(stripAnsi(expected));
   });
 
   it('should throw NoSupportedFiles when no projects', async () => {
@@ -138,6 +139,7 @@ describe('display', () => {
 
     expect(errorReceived.code).toEqual(ExitCode.NoSupportedFiles);
     expect(stripAnsi(errorReceived.message)).toContain(stripAnsi(expected));
+    expect(stripAnsi(errorReceived.userMessage)).toContain(stripAnsi(expected));
   });
 
   it('should throw NoSupportedFiles when invalid artifact data', async () => {
@@ -157,6 +159,7 @@ describe('display', () => {
 
     expect(errorReceived.code).toEqual(ExitCode.NoSupportedFiles);
     expect(stripAnsi(errorReceived.message)).toContain(stripAnsi(expected));
+    expect(stripAnsi(errorReceived.userMessage)).toContain(stripAnsi(expected));
   });
 
   it('should throw NoSupportedFiles when invalid artifacts', async () => {
@@ -180,6 +183,7 @@ describe('display', () => {
 
     expect(errorReceived.code).toEqual(ExitCode.NoSupportedFiles);
     expect(stripAnsi(errorReceived.message)).toContain(stripAnsi(expected));
+    expect(stripAnsi(errorReceived.userMessage)).toContain(stripAnsi(expected));
   });
 
   it('should throw NoSupportedFiles when invalid artifact data', async () => {
@@ -203,9 +207,10 @@ describe('display', () => {
 
     expect(errorReceived.code).toEqual(ExitCode.NoSupportedFiles);
     expect(stripAnsi(errorReceived.message)).toContain(stripAnsi(expected));
+    expect(stripAnsi(errorReceived.userMessage)).toContain(stripAnsi(expected));
   });
 
-  it('should throw NoSupportedFiles containing expected text for error', async () => {
+  it('should throw Error containing expected text for error', async () => {
     const { scanResults } = await scan({ path: helloWorldPath });
     const errors: string[] = [
       'Could not test dependencies in test/fixtures/invalid',


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- add userMessage to the thrown errors
- update the message for the NoSupportedFiles case

