### PR TITLE
fix: use correct field from policy file

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -155,6 +155,6 @@ export function getExcludedPatterns(
 
   return [
     policyFilePath,
-    ...dotSnyk.toAbsolutePaths(projectRoot, config?.exclude?.unmanaged),
+    ...dotSnyk.toAbsolutePaths(projectRoot, config?.exclude?.global),
   ];
 }

--- a/lib/utils/dotsnyk/types.ts
+++ b/lib/utils/dotsnyk/types.ts
@@ -13,4 +13,4 @@ export type Glob = string;
 //     - tests?/* # files directly inside “test” and/or “tests” directories
 //     - tests/** # all files and directories inside “tests”
 
-export type Config = { exclude?: { unmanaged?: Glob[] } };
+export type Config = { exclude?: { global?: Glob[] } };

--- a/test/fixtures/to-exclude-paths/.snyk
+++ b/test/fixtures/to-exclude-paths/.snyk
@@ -1,5 +1,5 @@
 exclude:
-  unmanaged:
+  global:
     - headers/one/headers/file-to-exclude.cpp
     - one
     - templates/**/test.tpl

--- a/test/fixtures/to-exclude-paths/.snyk-custom
+++ b/test/fixtures/to-exclude-paths/.snyk-custom
@@ -1,4 +1,4 @@
 exclude:
-  unmanaged:
+  global:
     - headers/one/headers/file-to-exclude.cpp
     - one

--- a/test/utils/dotsnyk.test.ts
+++ b/test/utils/dotsnyk.test.ts
@@ -10,7 +10,7 @@ describe('parseDotSnyk', () => {
 
     expect(result).toEqual({
       exclude: {
-        unmanaged: [
+        global: [
           'headers/one/headers/file-to-exclude.cpp',
           'one',
           'templates/**/test.tpl',


### PR DESCRIPTION
Use exclude>global in the policy file to decide what
file patterns to exclude.

- Read file pattern-list from exclude > global
- Ignore file pattern-list from exclude > unmanaged

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team