### PR TITLE
feat: Add support for objects and expiries in .snyk files during scan

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -153,8 +153,23 @@ export function getExcludedPatterns(
 
   const config: DotSnykConfig = dotSnyk.parse(policyFilePath);
 
-  return [
-    policyFilePath,
-    ...dotSnyk.toAbsolutePaths(projectRoot, config?.exclude?.global),
-  ];
+  const paths: readonly string[] | undefined = config?.exclude?.global
+    ?.filter((item) => {
+      if (typeof item === 'object') {
+        const key = Object.keys(item)[0];
+
+        return !key ? false : !dotSnyk.hasExpired(item[key].expires);
+      }
+
+      return true;
+    })
+    .map((item) => {
+      if (typeof item === 'object') {
+        return Object.keys(item)[0];
+      }
+
+      return item;
+    });
+
+  return [policyFilePath, ...dotSnyk.toAbsolutePaths(projectRoot, paths)];
 }

--- a/lib/utils/dotsnyk/index.ts
+++ b/lib/utils/dotsnyk/index.ts
@@ -34,3 +34,20 @@ export function toAbsolutePaths(
 ): Path[] {
   return paths.map((p) => resolve(basedir, p));
 }
+
+/**
+ * Resolves an array of paths relative to the basedir
+ * @param {string} expires - date string
+ * @returns {boolean} - whether or not the provided date has expired
+ */
+export function hasExpired(expires?: string | null): boolean {
+  if (expires === null || expires === undefined) {
+    return false;
+  }
+
+  if (isNaN(Date.parse(expires))) {
+    throw `Invalid date format provided dates should be formatted as "yyyy-MM-ddTHH:mm:ss.fffZ"`;
+  }
+
+  return new Date() > new Date(expires);
+}

--- a/lib/utils/dotsnyk/types.ts
+++ b/lib/utils/dotsnyk/types.ts
@@ -1,5 +1,13 @@
 export type Glob = string;
 
+type PathMeta = {
+  [key: string]: {
+    reason: string;
+    expires: string;
+    created: string;
+  };
+};
+
 // Example configuration:
 // # Snyk (https://snyk.io) policy file
 // version: v1.14.0
@@ -13,4 +21,4 @@ export type Glob = string;
 //     - tests?/* # files directly inside “test” and/or “tests” directories
 //     - tests/** # all files and directories inside “tests”
 
-export type Config = { exclude?: { global?: Glob[] } };
+export type Config = { exclude?: { global?: (Glob | PathMeta)[] } };

--- a/test/fixtures/to-exclude-paths/.snyk
+++ b/test/fixtures/to-exclude-paths/.snyk
@@ -3,3 +3,11 @@ exclude:
     - headers/one/headers/file-to-exclude.cpp
     - one
     - templates/**/test.tpl
+    - ./deps/grep-ok-*:
+        reason: this will always work
+        expires: 2122-10-28T08:36:02.845Z
+        created: 2022-03-28T08:36:02.845Z
+    - ./deps/grep-expired-*:
+        reason: this has expired
+        expires: 2021-10-28T08:36:02.845Z
+        created: 2022-03-28T08:36:02.845Z

--- a/test/fixtures/to-exclude-paths/.snyk-bad-date
+++ b/test/fixtures/to-exclude-paths/.snyk-bad-date
@@ -1,0 +1,6 @@
+exclude:
+  global:
+    - ./deps/grep-error-*:
+        reason: malformed date
+        expires: invalid-date
+        created: 2022-03-28T08:36:02.845Z

--- a/test/fixtures/to-exclude-paths/.snyk-empty-path
+++ b/test/fixtures/to-exclude-paths/.snyk-empty-path
@@ -1,0 +1,6 @@
+exclude:
+  global:
+    - :
+        reason: missing path
+        expires: 2100-03-28T08:36:02.845Z
+        created: 2022-03-28T08:36:02.845Z

--- a/test/fixtures/to-exclude-paths/.snyk-expires
+++ b/test/fixtures/to-exclude-paths/.snyk-expires
@@ -1,0 +1,9 @@
+exclude:
+  global:
+    - ./deps/grep-none-*:
+        reason: no expires provided
+        created: 2022-03-28T08:36:02.845Z
+    - ./deps/grep-null-*:
+        reason: no expires value
+        expires:
+        created: 2022-03-28T08:36:02.845Z  

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -119,7 +119,7 @@ describe('scan', () => {
       false,
     );
 
-    expect(hashedPaths.length).toEqual(17);
+    expect(hashedPaths.length).toEqual(20);
   });
 
   it('should produce scanned projects with project name option', async () => {
@@ -1282,6 +1282,7 @@ describe('scan', () => {
         join(basedir, 'headers', 'one', 'headers', 'file-to-exclude.cpp'),
         join(basedir, 'one'),
         join(basedir, 'templates', '**', 'test.tpl'),
+        join(basedir, 'deps/grep-ok-*'),
       ]);
     });
 
@@ -1301,6 +1302,56 @@ describe('scan', () => {
         join(basedir, 'headers', 'one', 'headers', 'file-to-exclude.cpp'),
         join(basedir, 'one'),
       ]);
+    });
+
+    it('should not filter glob-patterns that have no expiry information', async () => {
+      const basedir = join(__dirname, 'fixtures', 'to-exclude-paths');
+      const customPolicyPath = join(
+        __dirname,
+        'fixtures',
+        'to-exclude-paths',
+        '.snyk-expires',
+      );
+
+      const result: string[] = getExcludedPatterns(basedir, customPolicyPath);
+
+      expect(result).toEqual([
+        join(basedir, '.snyk-expires'),
+        join(basedir, 'deps/grep-none-*'),
+        join(basedir, 'deps/grep-null-*'),
+      ]);
+    });
+
+    it('should filter glob-patterns that have no path', async () => {
+      const basedir = join(__dirname, 'fixtures', 'to-exclude-paths');
+      const customPolicyPath = join(
+        __dirname,
+        'fixtures',
+        'to-exclude-paths',
+        '.snyk-empty-path',
+      );
+
+      const result: string[] = getExcludedPatterns(basedir, customPolicyPath);
+
+      expect(result).toEqual([join(basedir, '.snyk-empty-path')]);
+    });
+
+    it('should throw an error with glob-patterns that have invalid expiry', async () => {
+      const basedir = join(__dirname, 'fixtures', 'to-exclude-paths');
+      const customPolicyPath = join(
+        __dirname,
+        'fixtures',
+        'to-exclude-paths',
+        '.snyk-bad-date',
+      );
+
+      try {
+        getExcludedPatterns(basedir, customPolicyPath);
+      } catch (err) {
+        expect(err).toEqual(
+          'Invalid date format provided dates should be formatted as "yyyy-MM-ddTHH:mm:ss.fffZ"',
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
Co-Authored-By: dekelund <daniel.ekelund@snyk.io>
Co-Authored-By: dagrest <david.agrest@snyk.io>

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This PR allows users to add globs with meta data to the .snyk file, when running a scan it will parse out these and exclude any that have expired.

