### PR TITLE
fix: scan-failing-on-empty-folder

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -67,6 +67,10 @@ export async function scan(options: Options): Promise<PluginResponse> {
     );
     const [filePaths, archivePaths] = await find(projectRoot, excludedPatterns);
 
+    if (!filePaths.length) {
+      throw 'There were no files in the target directory that could be scanned. Check if the directory is empty or if an ignore policy is active.';
+    }
+
     let extractionWorkspace: FilePath | undefined = undefined;
 
     if (0 < extractionDepthLimit && 0 < archivePaths.length) {

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -165,6 +165,18 @@ describe('scan', () => {
     }
   });
 
+  it('should throw an exception if there are no files', async () => {
+    const expected = new Error(
+      `Could not scan C/C++ project: There were no files in the target directory that could be scanned. Check if the directory is empty or if an ignore policy is active.`,
+    );
+    try {
+      const fixturePath = join(__dirname, 'fixtures', 'empty');
+      await scan({ path: fixturePath });
+    } catch (err) {
+      expect(err).toEqual(expected);
+    }
+  });
+
   it('should throw exception when invalid options', async () => {
     expect.assertions(1);
     const expected = new Error(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This fix will stop the CLI from passing empty values to registry which results in a 500 error. Instead we will now throw an error if files are not found.

