### PR TITLE
fix: support --project-name

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -125,7 +125,7 @@ export async function scan(options: Options): Promise<PluginResponse> {
     debug('target %o \n', target);
     const gitInfo = fromUrl(target.remoteUrl);
     const name =
-      options.projectName || gitInfo?.project || path.basename(projectRoot);
+      options['project-name'] || gitInfo?.project || path.basename(projectRoot);
     debug('name %o \n', name);
     const scanResults: ScanResult[] = [
       {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -45,11 +45,11 @@ export interface Fingerprint {
 export interface Options {
   path: string;
   debug?: boolean;
-  projectName?: string;
   'print-deps'?: boolean;
   'print-dep-paths'?: boolean;
   'max-depth'?: number;
   'policy-path'?: string;
+  'project-name'?: string;
 }
 
 export interface Issue {

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -124,7 +124,7 @@ describe('scan', () => {
 
   it('should produce scanned projects with project name option', async () => {
     const fixturePath = join(__dirname, 'fixtures', 'hello-world');
-    const actual = await scan({ path: fixturePath, projectName: 'my-app' });
+    const actual = await scan({ path: fixturePath, 'project-name': 'my-app' });
     const expected: PluginResponse = {
       scanResults: [
         {


### PR DESCRIPTION
Support --project-name by reading CLI-option 'project-name' instead
of reading 'projectName'

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team
