### PR TITLE
fix: target reference handling

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -127,6 +127,8 @@ export async function scan(options: Options): Promise<PluginResponse> {
     const name =
       options['project-name'] || gitInfo?.project || path.basename(projectRoot);
     debug('name %o \n', name);
+    const targetReference = options['target-reference'];
+
     const scanResults: ScanResult[] = [
       {
         facts,
@@ -136,6 +138,7 @@ export async function scan(options: Options): Promise<PluginResponse> {
         name,
         target,
         analytics,
+        targetReference,
       },
     ];
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,6 +11,7 @@ export interface ScanResult {
   policy?: string;
   target: GitTarget;
   analytics?: Analytics[];
+  targetReference?: string;
 }
 
 export interface DepsFilePaths {
@@ -50,6 +51,7 @@ export interface Options {
   'max-depth'?: number;
   'policy-path'?: string;
   'project-name'?: string;
+  'target-reference'?: string;
 }
 
 export interface Issue {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- propagate the target reference value to the ScanResult

#### Screenshots

While executing the `monitor` command, the project will be 'target reference' aware.

<img width="1824" alt="Screenshot 2022-04-13 at 19 15 12" src="https://user-images.githubusercontent.com/6909300/163226698-3d1d720b-6187-4e7b-a8e7-409fcdcde869.png">

