### PR TITLE
feat: add support for custom remote-repo-url

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -129,6 +129,10 @@ export async function scan(options: Options): Promise<PluginResponse> {
     debug('name %o \n', name);
     const targetReference = options['target-reference'];
 
+    if (options['remote-repo-url']) {
+      target.remoteUrl = options['remote-repo-url'];
+    }
+
     const scanResults: ScanResult[] = [
       {
         facts,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,6 +52,7 @@ export interface Options {
   'policy-path'?: string;
   'project-name'?: string;
   'target-reference'?: string;
+  'remote-repo-url'?: string;
 }
 
 export interface Issue {

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -152,6 +152,39 @@ describe('scan', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('should produce scanned projects with a custom remote-repo-url', async () => {
+    const fixturePath = join(__dirname, 'fixtures', 'hello-world');
+    const actual = await scan({
+      path: fixturePath,
+      'remote-repo-url': 'custom-repo-url',
+    });
+    const expected: PluginResponse = {
+      scanResults: [
+        {
+          facts: helloWorldSignatures,
+          identity: {
+            type: 'cpp',
+          },
+          name: 'snyk-cpp-plugin',
+          target: {
+            remoteUrl: 'custom-repo-url',
+            branch: expect.any(String),
+          },
+          analytics: [
+            {
+              data: {
+                totalFileSignatures: 3,
+                totalSecondsElapsedToGenerateFileSignatures: expect.any(Number),
+              },
+              name: 'fileSignaturesAnalyticsContext',
+            },
+          ],
+        },
+      ],
+    };
+    expect(actual).toEqual(expected);
+  });
+
   it('should throw exception when invalid directory path', async () => {
     expect.assertions(1);
     const filePath = 'does/not/exist';


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This allows users to make use of the `--remote-repo-url` flag on the cli and override the value, e.g. `--remote-repo-url=dan-local`:

![image](https://user-images.githubusercontent.com/15086861/169496526-7923b4da-0f58-4e5b-a3f4-84533109c690.png)

