### PR TITLE
fix: pin semantic-release to pre-20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       - install_deps
       - run:
           name: Release
-          command: npx semantic-release
+          command: npx semantic-release@19
 
 workflows:
   version: 2


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Use semantic-release@19 required by the current build-pipeline
to be able to release a new version.