### PR TITLE
fix: ignore snyk code false alarms

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,3 +3,7 @@ version: v1.13.5
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch: {}
+exclude:
+  global:
+    - snyk-cpp-plugin/test/fixtures/to-exclude-paths/.snyk 
+


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?

Disables false-alarms for Snyk-vulns that is due to fixtures used to test the .snyk-policy file.