### PR TITLE
fix: vulns and licenses separated

### DIFF
--- a/lib/display/display.ts
+++ b/lib/display/display.ts
@@ -172,13 +172,17 @@ export function displayIssues(
   const hasIssues = issues.length > 0;
 
   if (hasIssues) {
-    const vulnerabilityIssues = issues.filter(
-      (issue) => issue.type === 'vulnerability',
-    );
-    if (vulnerabilityIssues.length > 0) {
-      prepareResults(result, vulnerabilityIssues, issuesData, 'Issues:');
+    const nonLicenseIssues = issues.filter((issue) => {
+      return issuesData[issue.issueId]?.type !== 'license';
+    });
+
+    if (nonLicenseIssues.length > 0) {
+      prepareResults(result, nonLicenseIssues, issuesData, 'Issues:');
     }
-    const licenseIssues = issues.filter((issue) => issue.type === 'license');
+
+    const licenseIssues = issues.filter(
+      (issue) => issuesData[issue.issueId]?.type === 'license',
+    );
     if (licenseIssues.length > 0) {
       prepareResults(result, licenseIssues, issuesData, 'License issues:');
     }
@@ -208,7 +212,7 @@ function prepareResults(
     pkgVersion: version,
     issueId: vulnId,
   } of issues) {
-    const { title, severity } = issuesData[vulnId];
+    const { title, severity, legalInstructionsArray } = issuesData[vulnId];
 
     const color = getColorBySeverity(severity);
     const severityAndTitle = color.bold(
@@ -227,6 +231,15 @@ function prepareResults(
     result.push(severityAndTitle);
     result.push(introducedThrough);
     result.push(urlText);
+    if (legalInstructionsArray) {
+      result.push(leftPad(chalk.bold(`Legal instructions:`), 3));
+      const { licenseName, legalContent } = legalInstructionsArray[0];
+      const legalInstructionsText = leftPad(
+        `○ for ${licenseName}: ${legalContent}`,
+        3,
+      );
+      result.push(legalInstructionsText);
+    }
   }
   result.push('');
 }

--- a/lib/display/index.ts
+++ b/lib/display/index.ts
@@ -34,12 +34,6 @@ export async function display(
     }
 
     for (const testResult of testResults) {
-      testResult.issues.forEach(
-        (issue) =>
-          (issue.type = issue.issueId.startsWith('snyk:lic:unmanaged:')
-            ? 'license'
-            : 'vulnerability'),
-      );
       const depGraph = createFromJSON(testResult.depGraphData);
       const [dependencies, issues] = selectDisplayStrategy(
         options,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -62,7 +62,6 @@ export interface Issue {
   fixInfo: {
     nearestFixedInVersion?: string;
   };
-  type?: string;
 }
 
 export interface IssuesData {
@@ -70,9 +69,15 @@ export interface IssuesData {
     id: string;
     severity: string;
     title: string;
+    type?: string | undefined;
+    legalInstructionsArray?: LegalInstruction[];
   };
 }
 
+export interface LegalInstruction {
+  licenseName: string;
+  legalContent: string;
+}
 export interface TestResult {
   issues: Issue[];
   issuesData: IssuesData;

--- a/test/display.test.ts
+++ b/test/display.test.ts
@@ -338,7 +338,6 @@ describe('display', () => {
         {
           pkgName: 'hello-world',
           pkgVersion: '1.2.3',
-          type: 'vulnerability',
           issueId: 'cpp:hello-world:20161130',
           fixInfo: { nearestFixedInVersion: '1.2.4' },
         },

--- a/test/fixtures/hello-world-display/display-one-dep-one-vuln-one-license-no-errors.txt
+++ b/test/fixtures/hello-world-display/display-one-dep-one-vuln-one-license-no-errors.txt
@@ -6,8 +6,10 @@
 
 [97mLicense issues:[39m
 [91m[39m
-[91m ✗ [Critical] SomeLicense[39m
+[91m ✗ [Critical] HU-7 license[39m
    Introduced through: hello-world@1.2.3
-   URL: https://security.snyk.io/vuln/snyk:lic:unmanaged:hello-world:SomeLicense
+   URL: https://security.snyk.io/vuln/snyk:lic:unmanaged:hello-world:HU-7
+   Legal instructions:
+   ○ for HU-7: Not complying license
 
 Tested 1 dependency for known issues, found [91m2 issues[39m.

--- a/test/fixtures/hello-world-display/test-results.ts
+++ b/test/fixtures/hello-world-display/test-results.ts
@@ -128,7 +128,7 @@ export const withDepOneVulnerabilityOneLicenseIssue: TestResult[] = [
       {
         pkgName: 'hello-world',
         pkgVersion: '1.2.3',
-        issueId: 'snyk:lic:unmanaged:hello-world:SomeLicense',
+        issueId: 'snyk:lic:unmanaged:hello-world:HU-7',
         fixInfo: {},
       }
     ],
@@ -138,10 +138,18 @@ export const withDepOneVulnerabilityOneLicenseIssue: TestResult[] = [
         severity: 'critical',
         title: 'Information Exposure',
       },
-      ['snyk:lic:unmanaged:hello-world:SomeLicense']: {
-        id: 'snyk:lic:unmanaged:hello-world:SomeLicense',
+      ['snyk:lic:unmanaged:hello-world:HU-7']: {
+        id: 'snyk:lic:unmanaged:hello-world:HU-7',
         severity: 'critical',
-        title: 'SomeLicense',
+        title: 'HU-7 license',
+        type: 'license',
+        legalInstructionsArray: [
+          {
+            licenseName: 'HU-7',
+            legalContent: 'Not complying license'
+
+        }
+      ]
       }
     },
   },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Type of licenses should be in IssuesData with only relevant licenses fields. Adding to display legal instructions of licenses. Matching the cpp license test to a license title format.

#### Any background context you want to provide?

This is part of improving c/cpp licenses detection in Open Beta.

#### Screenshots

<img width="577" alt="Screenshot 2023-04-13 at 13 48 38" src="https://user-images.githubusercontent.com/78362317/231736669-2feda714-1049-4cda-8c96-7a6529e07433.png">
