### PR TITLE
fix: support tar files-only projects

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -74,7 +74,7 @@ export async function scan(options: Options): Promise<PluginResponse> {
 
     const [filePaths, archivePaths] = await find(projectRoot, excludedPatterns);
 
-    if (!filePaths.length) {
+    if (filePaths.length + archivePaths.length == 0) {
       throw 'There were no files in the target directory that could be scanned. Check if the directory is empty or if an ignore policy is active.';
     }
 


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?

Current implementation rejects project that lack source code, even if the project contains compressed archives with source code. This PR makes sure that we support those kinds of projects.

#### How should this be manually tested?

1. Create a directory with a tar-file containing a dependency, and create a file in the same directory. For instance README.md.
2. Run `snyk test --unmanaged` (We expect the dependency to be listed in this case)
3. Remove the file, but keep the archive
4. Run `snyk test --unmanaged` (We expect the dependency to still be listed in the output)