### PR TITLE
fix: use correct exit code for no files

### DIFF
--- a/lib/display/index.ts
+++ b/lib/display/index.ts
@@ -21,7 +21,6 @@ export async function display(
 
   let result: string[] = [];
 
-  let hasDependencies = false;
   let hasVulnerabilities = false;
 
   try {
@@ -48,10 +47,6 @@ export async function display(
         testResult,
       );
 
-      if (testResult.depGraphData.pkgs.length > 1) {
-        hasDependencies = true;
-      }
-
       if (testResult.issues.length > 0) {
         hasVulnerabilities = true;
       }
@@ -67,17 +62,6 @@ export async function display(
 
   if (hasVulnerabilities) {
     exitWith(ExitCode.VulnerabilitiesFound, output, testResults);
-  }
-
-  if (!hasDependencies) {
-    exitWith(
-      ExitCode.NoSupportedFiles,
-      `${output}\nCould not find any source code matching the Snyk database of open source dependencies in ${
-        options?.path
-      }\nPlease see our documentation for supported languages and target files: ${chalk.underline(
-        'https://snyk.co/udVgQ',
-      )} and make sure you are in the right directory.`,
-    );
   }
 
   return output;

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -23,6 +23,7 @@ import { DECOMPRESSING_WORKSPACE_DIR, isWin } from './common';
 import * as dotSnyk from './utils/dotsnyk';
 import { Config as DotSnykConfig, Glob } from './utils/dotsnyk/types';
 import { DEFAULT_SNYK_POLICY_FILE } from './utils/dotsnyk/invariants';
+import { ExitCode, exitWith } from './utils/error';
 
 export function toRelativePaths(
   basedir: Path,
@@ -75,7 +76,10 @@ export async function scan(options: Options): Promise<PluginResponse> {
     const [filePaths, archivePaths] = await find(projectRoot, excludedPatterns);
 
     if (filePaths.length + archivePaths.length == 0) {
-      throw 'There were no files in the target directory that could be scanned. Check if the directory is empty or if an ignore policy is active.';
+      exitWith(
+        ExitCode.NoSupportedFiles,
+        `There were no files in the target directory that could be scanned. Check if the directory is empty or if an ignore policy is active.`,
+      );
     }
 
     let extractionWorkspace: FilePath | undefined = undefined;
@@ -156,8 +160,12 @@ export async function scan(options: Options): Promise<PluginResponse> {
     return {
       scanResults,
     };
-  } catch (error) {
-    throw new Error(`Could not scan C/C++ project: ${error}`);
+  } catch (err) {
+    if (err.code != undefined) {
+      throw err;
+    }
+
+    throw new Error(`Could not scan C/C++ project: ${err}`);
   }
 }
 

--- a/test/display.test.ts
+++ b/test/display.test.ts
@@ -3,14 +3,13 @@ import * as path from 'path';
 import stripAnsi from 'strip-ansi';
 
 import * as displayModule from '../lib/display/display';
-import { display, Options, scan, ScanResult } from '../lib';
+import { display, Options, scan } from '../lib';
 import { readFixture } from './read-fixture';
 import {
   withDepOneIssueAndFix,
   withDepFourIssues,
   withDepOneVulnerabilityOneLicenseIssue,
   withDepNoIssues,
-  noDepOrIssues,
 } from './fixtures/hello-world-display/test-results';
 import { isWin } from '../lib/common';
 import { ExitCode } from '../lib/utils/error';
@@ -123,116 +122,6 @@ describe('display', () => {
 
     const result = await display(scanResults, withDepNoIssues, errors);
     expect(stripAnsi(result)).toEqual(stripAnsi(expected));
-  });
-
-  it('should throw NoSupportedFiles when no dependencies, no issues, no errors', async () => {
-    const { scanResults } = await scan({ path: helloWorldPath });
-    const errors: string[] = [];
-    const expected = await readFixture(
-      'hello-world-display',
-      'display-no-scan-results.txt',
-    );
-
-    let errorReceived: any = null;
-
-    try {
-      await display(scanResults, noDepOrIssues, errors);
-    } catch (error) {
-      errorReceived = error;
-    }
-
-    expect(errorReceived.code).toEqual(ExitCode.NoSupportedFiles);
-    expect(stripAnsi(errorReceived.message)).toContain(stripAnsi(expected));
-    expect(stripAnsi(errorReceived.userMessage)).toContain(stripAnsi(expected));
-  });
-
-  it('should throw NoSupportedFiles when no projects', async () => {
-    const scanResult: ScanResult[] = [];
-    const errors: string[] = [];
-    const expected = await readFixture(
-      'hello-world-display',
-      'display-no-scan-results.txt',
-    );
-
-    let errorReceived: any = null;
-
-    try {
-      await display(scanResult, noDepOrIssues, errors);
-    } catch (error) {
-      errorReceived = error;
-    }
-
-    expect(errorReceived.code).toEqual(ExitCode.NoSupportedFiles);
-    expect(stripAnsi(errorReceived.message)).toContain(stripAnsi(expected));
-    expect(stripAnsi(errorReceived.userMessage)).toContain(stripAnsi(expected));
-  });
-
-  it('should throw NoSupportedFiles when invalid artifact data', async () => {
-    const errors: string[] = [];
-    const expected = await readFixture(
-      'hello-world-display',
-      'display-no-scan-results.txt',
-    );
-
-    let errorReceived: any = null;
-
-    try {
-      await display([1, 2, 3] as any, noDepOrIssues, errors);
-    } catch (error) {
-      errorReceived = error;
-    }
-
-    expect(errorReceived.code).toEqual(ExitCode.NoSupportedFiles);
-    expect(stripAnsi(errorReceived.message)).toContain(stripAnsi(expected));
-    expect(stripAnsi(errorReceived.userMessage)).toContain(stripAnsi(expected));
-  });
-
-  it('should throw NoSupportedFiles when invalid artifacts', async () => {
-    const errors: string[] = [];
-    const expected = await readFixture(
-      'hello-world-display',
-      'display-no-scan-results.txt',
-    );
-
-    let errorReceived: any = null;
-
-    try {
-      await display(
-        [{ artifacts: ['a', 'b', 'c'] }] as any,
-        noDepOrIssues,
-        errors,
-      );
-    } catch (error) {
-      errorReceived = error;
-    }
-
-    expect(errorReceived.code).toEqual(ExitCode.NoSupportedFiles);
-    expect(stripAnsi(errorReceived.message)).toContain(stripAnsi(expected));
-    expect(stripAnsi(errorReceived.userMessage)).toContain(stripAnsi(expected));
-  });
-
-  it('should throw NoSupportedFiles when invalid artifact data', async () => {
-    const errors: string[] = [];
-    const expected = await readFixture(
-      'hello-world-display',
-      'display-no-scan-results.txt',
-    );
-
-    let errorReceived: any = null;
-
-    try {
-      await display(
-        [{ artifacts: [{ type: 'test', data: [1, 2, 3] }] }] as any,
-        noDepOrIssues,
-        errors,
-      );
-    } catch (error) {
-      errorReceived = error;
-    }
-
-    expect(errorReceived.code).toEqual(ExitCode.NoSupportedFiles);
-    expect(stripAnsi(errorReceived.message)).toContain(stripAnsi(expected));
-    expect(stripAnsi(errorReceived.userMessage)).toContain(stripAnsi(expected));
   });
 
   it('should throw Error containing expected text for error', async () => {

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -200,7 +200,7 @@ describe('scan', () => {
 
   it('should throw an exception if there are no files', async () => {
     const expected = new Error(
-      `Could not scan C/C++ project: There were no files in the target directory that could be scanned. Check if the directory is empty or if an ignore policy is active.`,
+      `There were no files in the target directory that could be scanned. Check if the directory is empty or if an ignore policy is active.`,
     );
     try {
       const fixturePath = join(__dirname, 'fixtures', 'empty');


### PR DESCRIPTION
Throws an error with an exit code, to indicate no files found.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team