### PR TITLE
feat: add purl-support for unmanaged

### DIFF
--- a/lib/display/display.ts
+++ b/lib/display/display.ts
@@ -96,6 +96,12 @@ export function displayDependencies(
 
     result.push(`\n${leftPad(dependencyName, 2)}`);
 
+    if (fileSignaturesDetails && fileSignaturesDetails[dependencyId]?.purl) {
+      result.push(
+        leftPad(`purl: ${fileSignaturesDetails[dependencyId].purl}`, 2),
+      );
+    }
+
     if (
       fileSignaturesDetails &&
       fileSignaturesDetails[dependencyId]?.confidence

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -90,6 +90,7 @@ export interface FileSignaturesDetails {
   [pkgKey: string]: {
     confidence: number;
     filePaths: string[];
+    purl?: string;
   };
 }
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Adds package URL to dependencies list. This requires the backend to return PURLs in the first place, the output will be omitted if the prerequisite is not met.

#### Screenshots
Output when prerequisite has been met:
<img width="916" alt="image" src="https://github.com/snyk/snyk-cpp-plugin/assets/833396/8d161a1e-38f2-4fa4-a1c6-c4fdab2e1354">

Output when prerequisite was not met:
<img width="916" alt="image" src="https://github.com/snyk/snyk-cpp-plugin/assets/833396/61b20039-6b32-42bf-8a5c-03c6ea9f1618">