### PR TITLE
fix: replace gz with tar.gz

### DIFF
--- a/lib/extract.ts
+++ b/lib/extract.ts
@@ -16,7 +16,7 @@ const tar = require('tar');
 const { mkdir, rename } = promises;
 
 const zipFormats = ['.zip', '.zipx'];
-const tarFormats = ['.tar', '.gz', '.tgz'];
+const tarFormats = ['.tar', '.tar.gz', '.tgz'];
 
 interface ExtractionHandler {
   (path: FilePath): void;
@@ -115,7 +115,13 @@ export async function extract(
 }
 
 export function isTar(path: FilePath): boolean {
-  return tarFormats.includes(extname(path));
+  for (const format of tarFormats) {
+    if (path.endsWith(format)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function isZip(path: FilePath): boolean {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Use .tar.gz as suffix for tar gzip-files, instead of just gz.