### PR TITLE
fix: bump resource class of test runner to ensure tests pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ jobs:
     <<: *defaults
     docker:
       - image: cimg/node:<< parameters.node_version >>
+    resource_class: large
     steps:
       - checkout
       - show_node_npm_version


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

As shown [here](https://app.circleci.com/pipelines/github/snyk/snyk-cpp-plugin/870) the release keeps failing because the Unix Node 20 worker keeps getting killed, which I think is due to it OOMing. This PR bumps the resource class to try to fix that issue.