### PR TITLE
chore: update codeowners [unify-831]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/unify
+* @snyk/unify @snyk/codesec_unify


### PR DESCRIPTION
Duplicates [this PR](https://github.com/snyk/snyk-cpp-plugin/pull/122), as we were blocked there from getting the CLA signed.