### PR TITLE
chore: transfer ownership to @snyk/engines_sca-scanners [CMPA-724]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/open-source_unify @snyk/open-source_open-source-leadership
+* @snyk/engines_sca-scanners


### PR DESCRIPTION
### What?

- `.github/CODEOWNERS`: the ownership rule assigning `@snyk/open-source_unify` moves to `@snyk/engines_sca-scanners`, and `@snyk/open-source_open-source-leadership` is dropped as a co-owner since `@snyk/engines_sca-scanners` is now the repo owner.

### Why?

Ownership of this repo moves to `@snyk/engines_sca-scanners`, so review requests should land with them rather than the previous team.

`catalog-info.yaml` is deliberately left alone — changing the Backstage owner there would re-route Datadog/FireHydrant alerting, which is out of scope for this change.

---

> [!NOTE]
> **Low Risk**
> Metadata-only ownership update; no runtime or behavior changes.
